### PR TITLE
adds generics support to NameMustEndWithConventionSpecification

### DIFF
--- a/Conventional.Tests/Conventional/Conventions/ConventionSpecificationTests.cs
+++ b/Conventional.Tests/Conventional/Conventions/ConventionSpecificationTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using FluentAssertions;
 using NUnit.Framework;
 
@@ -191,6 +192,24 @@ namespace Conventional.Tests.Conventional.Conventions
 
             result.IsSatisfied.Should().BeFalse();
             result.Failures.Should().HaveCount(1);
+        }
+
+        private interface IFakeBusCommand
+        {
+        }
+
+        private interface IFakeHandleCommand<T> where T : IFakeBusCommand
+        {
+        }
+
+        [Test]
+        public void NameMustEndWithConventionSpecification_HandlesGenericCase()
+        {
+            var result = typeof(IFakeHandleCommand<>)
+                .MustConformTo(Convention.NameMustEndWith("HandleCommand"));
+
+            result.IsSatisfied.Should().BeTrue();
+            result.Failures.Should().HaveCount(0);
         }
 
         private class NamespaceMember

--- a/Conventional/Conventions/NameMustEndWithConventionSpecification.cs
+++ b/Conventional/Conventions/NameMustEndWithConventionSpecification.cs
@@ -18,12 +18,14 @@ namespace Conventional.Conventions
 
         public override ConventionResult IsSatisfiedBy(Type type)
         {
-            if (type.Name.EndsWith(_suffix) == false)
-            {
-                return ConventionResult.NotSatisfied(type.FullName, FailureMessage.FormatWith(_suffix));
-            }
+            var name = type.Name;
 
-            return ConventionResult.Satisfied(type.FullName);
+            if (type.IsGenericType)
+                name = name.Substring(0, name.IndexOf("`", StringComparison.Ordinal));
+
+            return name.EndsWith(_suffix) == false
+                ? ConventionResult.NotSatisfied(type.FullName, FailureMessage.FormatWith(_suffix))
+                : ConventionResult.Satisfied(type.FullName);
         }
     }
 }


### PR DESCRIPTION
by handling the `` `1 `` etc