### PR TITLE
Add generic property getter specification and refactor datetime specs…

### DIFF
--- a/Conventional.Net45/Conventional.Net45.csproj
+++ b/Conventional.Net45/Conventional.Net45.csproj
@@ -113,6 +113,9 @@
     <Compile Include="..\Conventional\Conventions\Cecil\MustNotUseDateTimeOffsetNowConventionSpecification.cs">
       <Link>Conventions\Cecil\MustNotUseDateTimeOffsetNowConventionSpecification.cs</Link>
     </Compile>
+    <Compile Include="..\Conventional\Conventions\Cecil\MustNotUsePropertyGetterSpecification.cs">
+      <Link>Conventions\Cecil\MustNotUsePropertyGetterSpecification.cs</Link>
+    </Compile>
     <Compile Include="..\Conventional\Conventions\CollectionPropertiesMustBeImmutableConventionSpecification.cs">
       <Link>Conventions\CollectionPropertiesMustBeImmutableConventionSpecification.cs</Link>
     </Compile>

--- a/Conventional/Conventional.csproj
+++ b/Conventional/Conventional.csproj
@@ -70,6 +70,7 @@
     <Compile Include="Conventions\Cecil\MustInstantiatePropertiesOfSpecifiedTypeInDefaultConstructor.cs" />
     <Compile Include="Conventions\Cecil\MustNotResolveCurrentTimeViaDateTimeConventionSpecification.cs" />
     <Compile Include="Conventions\Cecil\MustNotUseDateTimeOffsetNowConventionSpecification.cs" />
+    <Compile Include="Conventions\Cecil\MustNotUsePropertyGetterSpecification.cs" />
     <Compile Include="Conventions\CollectionPropertiesMustBeImmutableConventionSpecification.cs" />
     <Compile Include="Conventions\ConventionException.cs" />
     <Compile Include="Conventions\ConventionSpecification.cs" />

--- a/Conventional/Conventions/Cecil/MustNotUseDateTimeOffsetNowConventionSpecification.cs
+++ b/Conventional/Conventions/Cecil/MustNotUseDateTimeOffsetNowConventionSpecification.cs
@@ -1,38 +1,13 @@
 ﻿using System;
-using System.Linq;
-using Conventional.Conventions;
-using Mono.Cecil;
-using Mono.Cecil.Cil;
+using System.Linq.Expressions;
 
 namespace Conventional.Cecil.Conventions
 {
-    public class MustNotUseDateTimeOffsetNowConventionSpecification : ConventionSpecification
+    public class MustNotUseDateTimeOffsetNowConventionSpecification : MustNotUsePropertyGetterSpecification<DateTimeOffset, DateTimeOffset>
     {
-        protected override string FailureMessage
+        public MustNotUseDateTimeOffsetNowConventionSpecification()
+            : base(new Expression<Func<DateTimeOffset, DateTimeOffset>>[] { x => DateTimeOffset.Now, x=>DateTimeOffset.UtcNow}, "Must not use DateTimeOffset.Now or DateTimeOffset.UtcNow. It is called {0} times in this type.")
         {
-            get { return "Must not use DateTimeOffset.Now or DateTimeOffset.UtcNow. It is called {0} times in this type."; }
-        }
-
-        public override ConventionResult IsSatisfiedBy(Type type)
-        {
-            var nowAssignments =
-                type.ToTypeDefinition()
-                    .Methods
-                    .Where(method => method.HasBody)
-                    .SelectMany(method => method.Body.Instructions)
-                    .Where(
-                        x =>
-                            x.OpCode == OpCodes.Call && x.Operand is MethodReference &&
-                            ((MethodReference) x.Operand).DeclaringType.FullName == "System.DateTimeOffset" &&
-                            (((MethodReference) x.Operand).Name == "get_Now" || ((MethodReference) x.Operand).Name == "get_UtcNow"))
-                    .ToArray();
-
-            if (nowAssignments.Any())
-            {
-                return ConventionResult.NotSatisfied(type.FullName, FailureMessage.FormatWith(nowAssignments.Count()));
-            }
-
-            return ConventionResult.Satisfied(type.FullName);
         }
     }
 }


### PR DESCRIPTION
Generic property getter spec will make it easy to add new custom conventions which check for usages of a given property.