### PR TITLE
Allow matching embedded resource convention to take a resource name matching function

### DIFF
--- a/Conventional.Tests/Conventional.Tests.csproj
+++ b/Conventional.Tests/Conventional.Tests.csproj
@@ -78,6 +78,10 @@
     <Compile Include="Conventional\Conventions\Database\ScriptNamespace.cs" />
     <Compile Include="Conventional\Conventions\Database\SqlScripts.cs" />
     <Compile Include="Conventional\Conventions\Solution\SolutionConventionSpecificationTests.cs" />
+    <EmbeddedResource Include="Conventional\Conventions\TestData\HasMatchingEmbeddedResource.testdata" />
+    <Compile Include="Conventional\Conventions\TestData\HasMatchingNonEmbeddedResource.cs" />
+    <Compile Include="Conventional\Conventions\TestData\HasMatchingEmbeddedResource.cs" />
+    <Compile Include="Conventional\Conventions\TestData\HasNoMatchingFile.cs" />
     <Compile Include="DogFoodConventions.cs" />
     <Compile Include="ExampleOutput\SampleOutputTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
@@ -120,6 +124,7 @@
     <EmbeddedResource Include="Conventional\Conventions\Database\Scripts\TablesWithoutClusteredIndexSuccess.sql" />
   </ItemGroup>
   <ItemGroup>
+    <Content Include="Conventional\Conventions\TestData\HasMatchingNonEmbeddedResource.testdata" />
     <EmbeddedResource Include="Conventional\Conventions\Assemblies\embedded_sql_file.sql" />
     <Content Include="Conventional\Conventions\Assemblies\non_embedded_text_file_first.txt" />
     <Content Include="Conventional\Conventions\Assemblies\non_embedded_text_file_second.txt" />

--- a/Conventional.Tests/Conventional/Conventions/ConventionSpecificationTests.cs
+++ b/Conventional.Tests/Conventional/Conventions/ConventionSpecificationTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using Conventional.Tests.Conventional.Conventions.TestData;
 using FluentAssertions;
 using NUnit.Framework;
 
@@ -550,6 +551,66 @@ namespace Conventional.Tests.Conventional.Conventions
 
             result.IsSatisfied.Should().BeFalse();
             result.Failures.Should().HaveCount(1);
+        }
+
+        [Test]
+        public void MustHaveMatchingEmbeddedResourcesConventionSpecification_Success_WithWildcardFileExtension()
+        {
+            var result = typeof(HasMatchingEmbeddedResource)
+                .MustConformTo(Convention.MustHaveMatchingEmbeddedResourcesConventionSpecification("*.testdata"));
+
+            result.IsSatisfied.Should().BeTrue();
+        }
+
+        [Test]
+        public void MustHaveMatchingEmbeddedResourcesConventionSpecification_Success_WithNonWildcardFileExtension()
+        {
+            var result = typeof(HasMatchingEmbeddedResource)
+                .MustConformTo(Convention.MustHaveMatchingEmbeddedResourcesConventionSpecification("testdata"));
+
+            result.IsSatisfied.Should().BeTrue();
+        }
+
+        [Test]
+        public void MustHaveMatchingEmbeddedResourcesConventionSpecification_Success_WithResourceNameMatcher()
+        {
+            var result = typeof(HasMatchingEmbeddedResource)
+                .MustConformTo(Convention.MustHaveMatchingEmbeddedResourcesConventionSpecification(t =>
+                    t.FullName + ".testdata"));
+
+            result.IsSatisfied.Should().BeTrue();
+        }
+
+        [Test]
+        public void MustHaveMatchingEmbeddedResourcesConventionSpecification_FailsWhenFileNotEmbeddedResource_FileExtension()
+        {
+            var result = typeof (HasMatchingNonEmbeddedResource)
+                .MustConformTo(Convention.MustHaveMatchingEmbeddedResourcesConventionSpecification("testdata"));
+
+            result.IsSatisfied.Should().BeFalse();
+            result.Failures.Count().Should().Be(1);
+        }
+
+        [Test]
+        public void MustHaveMatchingEmbeddedResourcesConventionSpecification_FailsWhenFileNotEmbeddedResource_ResourceNameMatcher()
+        {
+            var result = typeof (HasMatchingNonEmbeddedResource)
+                .MustConformTo(Convention.MustHaveMatchingEmbeddedResourcesConventionSpecification(t =>
+                    t.FullName + ".testdata"));
+
+            result.IsSatisfied.Should().BeFalse();
+            result.Failures.Count().Should().Be(1);
+        }
+
+        [Test]
+        public void MustHaveMatchingEmbeddedResourcesConventionSpecification_FailsWhenFileDoesntExist_ResourceNameMatcher()
+        {
+            var result = typeof(HasNoMatchingFile)
+                .MustConformTo(Convention.MustHaveMatchingEmbeddedResourcesConventionSpecification(t =>
+                    t.FullName + ".testdata"));
+
+            result.IsSatisfied.Should().BeFalse();
+            result.Failures.Count().Should().Be(1);
         }
     }
 }

--- a/Conventional.Tests/Conventional/Conventions/TestData/HasMatchingEmbeddedResource.cs
+++ b/Conventional.Tests/Conventional/Conventions/TestData/HasMatchingEmbeddedResource.cs
@@ -1,0 +1,7 @@
+﻿namespace Conventional.Tests.Conventional.Conventions.TestData
+{
+    public class HasMatchingEmbeddedResource
+    {
+         
+    }
+}

--- a/Conventional.Tests/Conventional/Conventions/TestData/HasMatchingEmbeddedResource.testdata
+++ b/Conventional.Tests/Conventional/Conventions/TestData/HasMatchingEmbeddedResource.testdata
@@ -1,0 +1,1 @@
+﻿I am an embedded resource :)

--- a/Conventional.Tests/Conventional/Conventions/TestData/HasMatchingNonEmbeddedResource.cs
+++ b/Conventional.Tests/Conventional/Conventions/TestData/HasMatchingNonEmbeddedResource.cs
@@ -1,0 +1,7 @@
+﻿namespace Conventional.Tests.Conventional.Conventions.TestData
+{
+    public class HasMatchingNonEmbeddedResource
+    {
+         
+    }
+}

--- a/Conventional.Tests/Conventional/Conventions/TestData/HasMatchingNonEmbeddedResource.testdata
+++ b/Conventional.Tests/Conventional/Conventions/TestData/HasMatchingNonEmbeddedResource.testdata
@@ -1,0 +1,1 @@
+﻿I am not an embedded resource :(

--- a/Conventional.Tests/Conventional/Conventions/TestData/HasNoMatchingFile.cs
+++ b/Conventional.Tests/Conventional/Conventions/TestData/HasNoMatchingFile.cs
@@ -1,0 +1,7 @@
+﻿namespace Conventional.Tests.Conventional.Conventions.TestData
+{
+    public class HasNoMatchingFile
+    {
+         
+    }
+}

--- a/Conventional/Convention.cs
+++ b/Conventional/Convention.cs
@@ -90,6 +90,11 @@ namespace Conventional
             return new MustHaveMatchingEmbeddedResourcesConventionSpecification(extension);
         }
 
+        public static MustHaveMatchingEmbeddedResourcesConventionSpecification MustHaveMatchingEmbeddedResourcesConventionSpecification(Func<Type, string> resourceNameMatcher)
+        {
+            return new MustHaveMatchingEmbeddedResourcesConventionSpecification(resourceNameMatcher);
+        }
+
         public static MustNotHaveAPropertyOfTypeConventionSpecification MustNotHaveAPropertyOfType(Type type, string reason)
         {
             return new MustNotHaveAPropertyOfTypeConventionSpecification(type, reason);


### PR DESCRIPTION
- Added ability to pass a function to MustHaveMatchingEmbeddedResourcesConventionSpecification in order to support matching to any embedded resource.
- Backwards compatible with extension based matching.