### PR TITLE
Failure message should use the attribute type

### DIFF
--- a/Conventional/Conventions/MustHaveAttributeConventionSpecification.cs
+++ b/Conventional/Conventions/MustHaveAttributeConventionSpecification.cs
@@ -27,7 +27,7 @@ namespace Conventional.Conventions
         {
             if (type.GetCustomAttributes(_attributeType, false).Any() == false)
             {
-                return ConventionResult.NotSatisfied(type.FullName, FailureMessage.FormatWith(type.FullName));
+                return ConventionResult.NotSatisfied(type.FullName, FailureMessage.FormatWith(_attributeType.FullName));
             }
 
             return ConventionResult.Satisfied(type.FullName);


### PR DESCRIPTION
The failure message currently shows the name of the type missing the attribute and not the name of the missing attribute itself.