### PR TITLE
Update NuGet-related MSBuild properties

### DIFF
--- a/Conventional/Conventional.csproj
+++ b/Conventional/Conventional.csproj
@@ -5,10 +5,10 @@
     <Title>Best.Conventional</Title>
     <Authors>Andrew Best</Authors>
     <Owners>Andrew Best</Owners>
-    <ProjectUrl>https://github.com/andrewabest/Conventional</ProjectUrl>
+    <PackageProjectUrl>https://github.com/andrewabest/Conventional</PackageProjectUrl>
     <RequireLicenseAcceptance>false</RequireLicenseAcceptance>
     <Description>A suite of convention specifications for enforcing type conventions in your codebase</Description>
-    <IconUrl>https://raw.github.com/andrewabest/Conventional/master/duck.png</IconUrl>
+    <PackageIconUrl>https://raw.github.com/andrewabest/Conventional/master/duck.png</PackageIconUrl>
     <Tags>Convention Testing</Tags>
     <Copyright>Copyright © 2017, Andrew Best</Copyright>
     <Version>0.0.0.0</Version>


### PR DESCRIPTION
As per https://docs.microsoft.com/en-us/dotnet/core/tools/csproj#nuget-metadata-properties

[Someone found out on Twitter](https://twitter.com/reubenbond/status/989649978380378112) that the NuGet package page doesn't link back to the GitHub repository.