### PR TITLE
Support iterator blocks, and support arbitrary method prohibition

### DIFF
--- a/Conventional.Tests/Conventional/Conventions/Cecil/CecilConventionSpecificationTests.cs
+++ b/Conventional.Tests/Conventional/Conventions/Cecil/CecilConventionSpecificationTests.cs
@@ -99,6 +99,27 @@ namespace Conventional.Tests.Conventional.Conventions.Cecil
             result.Failures.Should().HaveCount(1);
             result.Failures.First().Should().Contain(offendingType.FullName);
         }
+
+        private class OffendingDateTimeNowIteratorCitizen
+        {
+            public IEnumerable<DateTime> GetTimes()
+            {
+                yield return DateTime.Now;
+            }
+        }
+
+        [Test]
+        [TestCase(typeof(OffendingDateTimeNowIteratorCitizen))]
+        public void
+            MustNotResolveCurrentTimeViaDateTimeConventionSpecification_FailsWhenACallToDateTimeExistsInIteratorBlock(
+                Type offendingType)
+        {
+            var result = offendingType.MustConformTo(Convention.MustNotResolveCurrentTimeViaDateTime);
+
+            result.IsSatisfied.Should().BeFalse();
+            result.Failures.Should().HaveCount(1);
+            result.Failures.First().Should().Contain(offendingType.FullName);
+        }
         
         private class GoodDateTimeOffsetCitizen
         {

--- a/Conventional/Conventions/Cecil/CecilExtensions.cs
+++ b/Conventional/Conventions/Cecil/CecilExtensions.cs
@@ -68,6 +68,12 @@ namespace Conventional.Conventions.Cecil
             return (TypeDefinition)asyncStateMachineAttribute.ConstructorArguments[0].Value;
         }
 
+        public static TypeDefinition GetIteratorStateMachineType(this MethodDefinition provider)
+        {
+            var iteratorStateMachineAttribute = provider.GetAttribute<IteratorStateMachineAttribute>();
+            return (TypeDefinition) iteratorStateMachineAttribute.ConstructorArguments[0].Value;
+        }
+
         public static bool HasAttribute<TAttribute>(this MethodDefinition subject) where TAttribute : Attribute
         {
             return GetAttribute<TAttribute>(subject) != null;

--- a/Conventional/Conventions/Cecil/MustNotUseMethodSpecification.cs
+++ b/Conventional/Conventions/Cecil/MustNotUseMethodSpecification.cs
@@ -54,7 +54,7 @@ namespace Conventional.Conventions.Cecil
                         x => (((MethodReference)x.Operand).DeclaringType.FullName, ((MethodReference)x.Operand).Name),
                         g => (g.DeclaringType?.FullName, g.Name),
                         (x,g) => x)
-                    .ToArray();
+                    .Distinct().ToArray();
 
             if (assignments.Any())
             {

--- a/Conventional/Conventions/Cecil/MustNotUseMethodSpecification.cs
+++ b/Conventional/Conventions/Cecil/MustNotUseMethodSpecification.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using Mono.Cecil;
+using Mono.Cecil.Cil;
+
+namespace Conventional.Conventions.Cecil
+{
+    public abstract class MustNotUseMethodSpecification : ConventionSpecification
+    {
+        private readonly (string DeclaringType, string MethodName)[] _getterDetails;
+        private readonly MethodInfo[] _methodInfos;
+
+        protected MustNotUseMethodSpecification(MethodInfo methodInfo,
+            string failureMessage)
+            :this(new[] {methodInfo},failureMessage)
+        {
+        }
+
+        protected MustNotUseMethodSpecification(MethodInfo[] methodInfos, string failureMessage)
+        {
+            FailureMessage = failureMessage;
+            _methodInfos = methodInfos;
+        }
+
+        protected override string FailureMessage { get; }
+
+        public override ConventionResult IsSatisfiedBy(Type type)
+        {
+            var typeInstructions =
+                type.ToTypeDefinition()
+                    .Methods
+                    .Where(method => method.HasBody)
+                    .SelectMany(method => method.Body.Instructions)
+                    .Union(
+                        type.ToTypeDefinition()
+                            .Methods
+                            .Where(x => x.HasAttribute<AsyncStateMachineAttribute>())
+                            .SelectMany(x => x.GetAsyncStateMachineType().Methods.Where(method => method.HasBody))
+                            .SelectMany(method => method.Body.Instructions))
+                    .Union(
+                        type.ToTypeDefinition()
+                            .Methods
+                            .Where(x => x.HasAttribute<IteratorStateMachineAttribute>())
+                            .SelectMany(x => x.GetIteratorStateMachineType().Methods.Where(method => method.HasBody))
+                            .SelectMany(method => method.Body.Instructions));
+
+            var assignments =
+                typeInstructions
+                    .Where(x =>
+                        x.OpCode == OpCodes.Call && x.Operand is MethodReference)
+                    .Join(_methodInfos, 
+                        x => (((MethodReference)x.Operand).DeclaringType.FullName, ((MethodReference)x.Operand).Name),
+                        g => (g.DeclaringType?.FullName, g.Name),
+                        (x,g) => x)
+                    .ToArray();
+
+            if (assignments.Any())
+            {
+                return ConventionResult.NotSatisfied(type.FullName, FailureMessage.FormatWith(assignments.Count(), type.FullName));
+            }
+
+            return ConventionResult.Satisfied(type.FullName);
+        }
+    }
+}

--- a/Conventional/Conventions/Cecil/MustNotUsePropertyGetterSpecification.cs
+++ b/Conventional/Conventions/Cecil/MustNotUsePropertyGetterSpecification.cs
@@ -49,8 +49,13 @@ namespace Conventional.Conventions.Cecil
                             .Methods
                             .Where(x => x.HasAttribute<AsyncStateMachineAttribute>())
                             .SelectMany(x => x.GetAsyncStateMachineType().Methods.Where(method => method.HasBody))
-                            .SelectMany(method => method.Body.Instructions)
-                    );
+                            .SelectMany(method => method.Body.Instructions))
+                    .Union(
+                        type.ToTypeDefinition()
+                            .Methods
+                            .Where(x => x.HasAttribute<IteratorStateMachineAttribute>())
+                            .SelectMany(x => x.GetIteratorStateMachineType().Methods.Where(method => method.HasBody))
+                            .SelectMany(method => method.Body.Instructions));
 
             var assignments =
                 typeInstructions

--- a/Conventional/Conventions/Cecil/MustNotUsePropertyGetterSpecification.cs
+++ b/Conventional/Conventions/Cecil/MustNotUsePropertyGetterSpecification.cs
@@ -2,77 +2,32 @@
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
-using System.Runtime.CompilerServices;
-using Mono.Cecil;
-using Mono.Cecil.Cil;
 
 namespace Conventional.Conventions.Cecil
 {
-    public abstract class MustNotUsePropertyGetterSpecification<TClass, TMember> : ConventionSpecification
+    public abstract class MustNotUsePropertyGetterSpecification<TClass, TMember> : MustNotUseMethodSpecification
     {
-        private readonly (string DeclaringType, string MethodName)[] _getterDetails;
-
-        protected MustNotUsePropertyGetterSpecification(Expression<Func<TClass, TMember>> expression,
+        public MustNotUsePropertyGetterSpecification(Expression<Func<TClass, TMember>> expression,
             string failureMessage)
             :this(new[] {expression},failureMessage)
         {
         }
 
-        protected MustNotUsePropertyGetterSpecification(Expression<Func<TClass, TMember>>[] expressions, string failureMessage)
+        public MustNotUsePropertyGetterSpecification(Expression<Func<TClass, TMember>>[] expressions, string failureMessage):base(
+            expressions.Select(GetMethodInfoFromExpression).ToArray(), failureMessage)
         {
-            FailureMessage = failureMessage;
-
-            _getterDetails = expressions.Select(e =>
-            {
-                var memberExpression = (MemberExpression) e.Body;
-                var propertyInfo = memberExpression.Member as PropertyInfo;
-                if (propertyInfo == null)
-                {
-                    throw new ArgumentException("Expression must be a memberexpression selecting a single property.",
-                        nameof(expressions));
-                }
-                return (typeof (TClass).FullName, propertyInfo.GetGetMethod().Name);
-            }).ToArray();
         }
 
-        protected override string FailureMessage { get; }
-
-        public override ConventionResult IsSatisfiedBy(Type type)
+        private static MethodInfo GetMethodInfoFromExpression(Expression<Func<TClass, TMember>> expr)
         {
-            var typeInstructions =
-                type.ToTypeDefinition()
-                    .Methods
-                    .Where(method => method.HasBody)
-                    .SelectMany(method => method.Body.Instructions)
-                    .Union(
-                        type.ToTypeDefinition()
-                            .Methods
-                            .Where(x => x.HasAttribute<AsyncStateMachineAttribute>())
-                            .SelectMany(x => x.GetAsyncStateMachineType().Methods.Where(method => method.HasBody))
-                            .SelectMany(method => method.Body.Instructions))
-                    .Union(
-                        type.ToTypeDefinition()
-                            .Methods
-                            .Where(x => x.HasAttribute<IteratorStateMachineAttribute>())
-                            .SelectMany(x => x.GetIteratorStateMachineType().Methods.Where(method => method.HasBody))
-                            .SelectMany(method => method.Body.Instructions));
-
-            var assignments =
-                typeInstructions
-                    .Where(x =>
-                        x.OpCode == OpCodes.Call && x.Operand is MethodReference)
-                    .Join(_getterDetails, 
-                        x => (((MethodReference)x.Operand).DeclaringType.FullName, ((MethodReference)x.Operand).Name),
-                        g => (g.DeclaringType, g.MethodName),
-                        (x,g)=>x)
-                    .ToArray();
-
-            if (assignments.Any())
+            var memberExpression = (MemberExpression) expr.Body;
+            var propertyInfo = memberExpression.Member as PropertyInfo;
+            if (propertyInfo == null)
             {
-                return ConventionResult.NotSatisfied(type.FullName, FailureMessage.FormatWith(assignments.Count(), type.FullName));
+                throw new ArgumentException("Expression must be a memberexpression selecting a single property.",
+                    nameof(expr));
             }
-
-            return ConventionResult.Satisfied(type.FullName);
+            return propertyInfo.GetGetMethod();
         }
     }
 }


### PR DESCRIPTION
This PR implements my comments from [here](https://github.com/andrewabest/Conventional/pull/63).

- It searches generated types for iterator blocks for prohibited methods and
- Re-implements `MustNotUsePropertyGetterSpecification` in terms of a new `MustNotUseMethodSpecification` that has most of the logic from `MustNotUsePropertyGetterSpecification`, and now just converts the `Expression<Func<TClass, TMember>>` into a `MethodInfo` that can be searched for.