### PR TITLE
[GH-66] Cross-platformed path handling in KnownPaths

### DIFF
--- a/Conventional/KnownPaths.cs
+++ b/Conventional/KnownPaths.cs
@@ -6,8 +6,8 @@ namespace Conventional
 {
     public static class KnownPaths
     {
-        private static readonly Func<string, string> DefaultSolutionRootFinder = x => x.Substring(0, x.LastIndexOf("\\bin\\", StringComparison.Ordinal));
-        private static readonly Func<string> DefaultSolutionRoot = () => Path.GetFullPath(Path.Combine(SolutionRootFinder(AppContext.BaseDirectory), @"..\"));
+        private static readonly Func<string, string> DefaultSolutionRootFinder = x => x.Substring(0, x.LastIndexOf($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}", StringComparison.Ordinal));
+        private static readonly Func<string> DefaultSolutionRoot = () => Directory.GetParent(SolutionRootFinder(AppContext.BaseDirectory)).FullName + Path.DirectorySeparatorChar;
         private static readonly Func<string> DefaultPathToSolutionRoot = () => Directory.GetFiles(SolutionRoot, "*.sln", SearchOption.AllDirectories).FirstOrDefault();
 
         private static Func<string, string> _solutionRootFinder;
@@ -23,9 +23,9 @@ namespace Conventional
             get => _solutionRoot ?? DefaultSolutionRoot();
             set
             {
-                if (value.EndsWith(@"\") == false)
+                if (value.ToCharArray().Last() != Path.DirectorySeparatorChar)
                 {
-                    value += @"\";
+                    value += Path.DirectorySeparatorChar;
                 }
 
                 _solutionRoot = value;


### PR DESCRIPTION
Addresses GH-66

Note that there are still (quite a number of) other tests which fail on Linux (e.g. DoomsDay, `expectedFailureMessage` values in `AssemblyConventionSpecificationTests`)