### PR TITLE
Patch SqlClient vulnerability

### DIFF
--- a/src/Core/Conventional/Conventional.csproj
+++ b/src/Core/Conventional/Conventional.csproj
@@ -42,6 +42,6 @@
     <PackageReference Include="Microsoft.CSharp" Version="4.4.1" />
     <PackageReference Include="Mono.Cecil" Version="0.10.0" />
     <PackageReference Include="System.Data.Common" Version="4.3.0" />
-    <PackageReference Include="System.Data.SqlClient" Version="4.4.0" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.8.5" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Microsoft disclosed a [moderate vulnerability](https://github.com/advisories/GHSA-8g2p-5pqh-5jmc) on their SqlClient libraries affecting a few versions.

This PR updates such library to a patched version.

https://octopusdeploy.slack.com/archives/C04AD1H7LLC/p1668387022805969