### PR TITLE
Ensures interface assignments are appropriately delved

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -167,3 +167,4 @@ FakesAssemblies/
 
 /development.json
 **/.idea/*
+**/development.json

--- a/src/Core/Conventional.Tests/Conventional/Conventions/Cecil/CecilExtensionsTests.cs
+++ b/src/Core/Conventional.Tests/Conventional/Conventions/Cecil/CecilExtensionsTests.cs
@@ -1,0 +1,31 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using Conventional.Conventions.Cecil;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace Conventional.Tests.Conventional.Conventions.Cecil
+{
+    public class CecilExtensionsTests
+    {
+        private class HasBaseInterface : List<string> {}
+        
+        private class DerivedFromDerieved : Derived {}
+        
+        private class Derived : Base{}
+        
+        private class Base {}
+        
+        [Test]
+        public void IsAssignableTo_DelvesTypeHeirarchy_ToFindInterfaces()
+        {
+            typeof(HasBaseInterface).ToTypeDefinition().IsAssignableTo(typeof(IEnumerable)).Should().BeTrue();
+        }
+        
+        [Test]
+        public void IsAssignableTo_DelvesTypeHeirarchy_ToFindBases()
+        {
+            typeof(DerivedFromDerieved).ToTypeDefinition().IsAssignableTo(typeof(Base)).Should().BeTrue();
+        }
+    }
+}

--- a/src/Core/Conventional/Conventions/Cecil/CecilExtensions.cs
+++ b/src/Core/Conventional/Conventions/Cecil/CecilExtensions.cs
@@ -10,26 +10,29 @@ namespace Conventional.Conventions.Cecil
     {
         public static bool IsAssignableTo(this TypeDefinition type, Type derivedType)
         {
-            return
-                IsAssignableToInterface(type, derivedType) || IsAssignableToBase(type, derivedType);
+            return derivedType.IsInterface
+                ? IsAssignableToInterface(type, derivedType)
+                : IsAssignableToBase(type, derivedType);
         }
 
         public static bool IsAssignableToInterface(this TypeDefinition type, Type derivedType)
         {
             var cecilFormattedTypeName = derivedType.FullName.Replace("+", "/");
 
-            return type.Interfaces.Any(
-                i =>
-                    i.InterfaceType.FullName.Equals(cecilFormattedTypeName) ||
-                    i.InterfaceType.Resolve().Interfaces.Any(x => IsAssignableToInterface(x.InterfaceType.Resolve(), derivedType)));
+            return 
+                type.Interfaces.Any(
+                    i =>
+                        i.InterfaceType.FullName.Equals(cecilFormattedTypeName) ||
+                        i.InterfaceType.Resolve().Interfaces.Any(x => IsAssignableToInterface(x.InterfaceType.Resolve(), derivedType))) ||
+                (type.BaseType != null && type.BaseType.Resolve().IsAssignableToInterface(derivedType));
         }
         
         public static bool IsAssignableToBase(this TypeDefinition type, Type derivedType)
         {
             var cecilFormattedTypeName = derivedType.FullName.Replace("+", "/");
 
-            return (type.BaseType != null && type.BaseType.FullName.Equals(cecilFormattedTypeName)) ||
-                   (type.BaseType != null && IsAssignableToBase(type.BaseType.Resolve(), derivedType));
+            return type.BaseType != null &&
+                   (type.BaseType.FullName.Equals(cecilFormattedTypeName) || IsAssignableToBase(type.BaseType.Resolve(), derivedType));
         }
 
         public static IEnumerable<PropertyDefinition> GetPropertiesOfType(this TypeDefinition typeDefinition, Type type)


### PR DESCRIPTION
Currently the Cecil extensions for type definitions do not walk through base types when checking if a type is assignable to an interface. This PR ensures that happens, and adds a couple of tests to enforce the behaviour.