### PR TITLE
Fix assembly path resolving on mac

### DIFF
--- a/src/Core/Conventional.Tests/Conventional/Conventions/Cecil/ConventionalAssemblyResolverTests.cs
+++ b/src/Core/Conventional.Tests/Conventional/Conventions/Cecil/ConventionalAssemblyResolverTests.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Reflection;
+using Conventional.Conventions.Cecil;
+using Mono.Cecil;
+using NUnit.Framework;
+
+namespace Conventional.Tests.Conventional.Conventions.Cecil
+{
+    public class ConventionalAssemblyResolverTests
+    {
+        [Test]
+        public void CanResolvePathToAssembly()
+        {
+            var resolver = new ConventionalAssemblyResolver();
+            var assembly = Assembly.GetExecutingAssembly();
+            var ignored = Version.Parse("1.0.0");
+            var reference = new AssemblyNameReference(assembly.FullName, ignored);
+            Assert.DoesNotThrow(() => resolver.Resolve(reference));
+        }
+    }
+}

--- a/src/Core/Conventional/Conventions/Cecil/ConventionalAssemblyResolver.cs
+++ b/src/Core/Conventional/Conventions/Cecil/ConventionalAssemblyResolver.cs
@@ -42,9 +42,9 @@ namespace Conventional.Conventions.Cecil
         {
             var codebase = assembly.CodeBase.Replace(FileSchemePrefix, string.Empty);
 
-            return 
-                RuntimeInformation.IsOSPlatform(OSPlatform.Linux) ?
-                $"/{codebase}" : codebase;
+            return RuntimeInformation.IsOSPlatform(OSPlatform.Windows) 
+                ? codebase 
+                : $"/{codebase}";
         }
 
         protected virtual void Dispose(bool disposing)


### PR DESCRIPTION
We were getting errors when running on mac (both m1 and intel):
```
Could not find a part of the path '/Users/matt/dev/Octopus/OctopusDeploy/source/Octopus.IntegrationTests/bin/net6.0/Users/matt/dev/Octopus/OctopusDeploy/source/Octopus.IntegrationTests/bin/net6.0/Octopus.Server.MessageContracts.dll'.
   at Interop.ThrowExceptionForIoErrno(ErrorInfo errorInfo, String path, Boolean isDirectory, Func`2 errorRewriter)
   at Interop.CheckIo(Error error, String path, Boolean isDirectory, Func`2 errorRewriter)
   at Microsoft.Win32.SafeHandles.SafeFileHandle.Open(String path, OpenFlags flags, Int32 mode)
   at Microsoft.Win32.SafeHandles.SafeFileHandle.Open(String fullPath, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize)
   at System.IO.Strategies.OSFileStreamStrategy..ctor(String path, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize)
   at System.IO.Strategies.FileStreamHelpers.ChooseStrategy(FileStream fileStream, String path, FileMode mode, FileAccess access, FileShare share, Int32 bufferSize, FileOptions options, Int64 preallocationSize)
   at System.IO.FileStream..ctor(String path, FileMode mode, FileAccess access, FileShare share)
   at Mono.Cecil.ModuleDefinition.GetFileStream(String fileName, FileMode mode, FileAccess access, FileShare share)
   at Mono.Cecil.ModuleDefinition.ReadModule(String fileName, ReaderParameters parameters)
   at Mono.Cecil.AssemblyDefinition.ReadAssembly(String fileName, ReaderParameters parameters)
   at Conventional.Conventions.Cecil.ConventionalAssemblyResolver.Resolve(AssemblyNameReference name, ReaderParameters parameters)
   at Conventional.Conventions.Cecil.ConventionalAssemblyResolver.Resolve(AssemblyNameReference name)
   at Mono.Cecil.MetadataResolver.Resolve(TypeReference type)
   at Mono.Cecil.ModuleDefinition.Resolve(TypeReference type)
   at Mono.Cecil.TypeReference.Resolve()
   ... (my code) ...
```

The code appears to be assuming linux or windows, it wasn't allowing for mac (which should use the same code path as linux)