### PR TITLE
Adds a decompilation cache for cecil convention and uses it throughout

### DIFF
--- a/src/Core/Conventional.Tests/Conventional/Conventions/Cecil/CecilConventionSpecificationTests.cs
+++ b/src/Core/Conventional.Tests/Conventional/Conventions/Cecil/CecilConventionSpecificationTests.cs
@@ -74,7 +74,7 @@ namespace Conventional.Tests.Conventional.Conventions.Cecil
 
             result.IsSatisfied.Should().BeFalse();
             result.Failures.Should().HaveCount(1);
-            result.Failures.First().Should().Contain(offendingType.FullName);
+            result.Failures.First().Should().Contain(nameof(DateTime));
         }
 
         private class OffendingDateTimeNowAsyncCitizen
@@ -97,7 +97,7 @@ namespace Conventional.Tests.Conventional.Conventions.Cecil
 
             result.IsSatisfied.Should().BeFalse();
             result.Failures.Should().HaveCount(1);
-            result.Failures.First().Should().Contain(offendingType.FullName);
+            result.Failures.First().Should().Contain(nameof(DateTime));
         }
 
         private class OffendingDateTimeNowIteratorCitizen
@@ -118,7 +118,7 @@ namespace Conventional.Tests.Conventional.Conventions.Cecil
 
             result.IsSatisfied.Should().BeFalse();
             result.Failures.Should().HaveCount(1);
-            result.Failures.First().Should().Contain(offendingType.FullName);
+            result.Failures.First().Should().Contain(nameof(DateTime));
         }
         
         private class GoodDateTimeOffsetCitizen

--- a/src/Core/Conventional/Conventions/Cecil/AllPropertiesMustBeAssignedDuringConstructionConventionSpecification.cs
+++ b/src/Core/Conventional/Conventions/Cecil/AllPropertiesMustBeAssignedDuringConstructionConventionSpecification.cs
@@ -18,8 +18,8 @@ namespace Conventional.Conventions.Cecil
 
         public override ConventionResult IsSatisfiedBy(Type type)
         {
-            var typeDefinition = type.ToTypeDefinition();
-
+            var typeDefinition = DecompilationCache.GetTypeDefinitionFor(type);
+            
             var subjects = typeDefinition.Properties;
 
             var subjectPropertySetters = subjects

--- a/src/Core/Conventional/Conventions/Cecil/DecompilationCache.cs
+++ b/src/Core/Conventional/Conventions/Cecil/DecompilationCache.cs
@@ -1,0 +1,147 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using Mono.Cecil;
+using Mono.Cecil.Cil;
+
+namespace Conventional.Conventions.Cecil
+{
+    public static class DecompilationCache
+    {
+        static readonly ConcurrentDictionary<string, ModuleDefinition> ModuleDefinitionsByAssemblyLocation;
+        static readonly ConcurrentDictionary<Type, TypeDefinition> TypeDefinitionsByType;
+        static readonly ConcurrentDictionary<Type, IReadOnlyCollection<Instruction>> InstructionsByType;
+        static readonly ConcurrentDictionary<Type, IReadOnlyCollection<Instruction>> StateMachineInstructionsByType;
+        static readonly object CecilMutex; // Cecil is not internally thread-safe in some places
+
+        static DecompilationCache()
+        {
+            ModuleDefinitionsByAssemblyLocation = new ConcurrentDictionary<string, ModuleDefinition>();
+            TypeDefinitionsByType = new ConcurrentDictionary<Type, TypeDefinition>();
+            InstructionsByType = new ConcurrentDictionary<Type, IReadOnlyCollection<Instruction>>();
+            StateMachineInstructionsByType = new ConcurrentDictionary<Type, IReadOnlyCollection<Instruction>>();
+            CecilMutex = new object();
+        }
+
+        public static IReadOnlyCollection<Instruction> InstructionsFor(Type type, bool includeStateMachine = true)
+        {
+            var typeInstructions = InstructionsByType.GetOrAdd(type, GetInstructionsFor(type));
+
+            if (includeStateMachine)
+            {
+                var stateMachineTypeInstructions = StateMachineInstructionsByType.GetOrAdd(type, GetStateMachineInstructions(type));
+
+                return typeInstructions
+                    .Union(stateMachineTypeInstructions)
+                    .Distinct()
+                    .ToArray();
+            }
+
+            return typeInstructions;
+        }
+
+        static IReadOnlyCollection<Instruction> GetInstructionsFor(Type type)
+        {
+            var typeDefinition = TypeDefinitionsByType.GetOrAdd(type, GetTypeDefinitionFor);
+
+            lock (CecilMutex)
+            {
+                var typeInstructions =
+                    typeDefinition
+                        .Methods
+                        .Where(method => method.HasBody)
+                        .SelectMany(method => method.Body.Instructions)
+                        .Distinct()
+                        .ToArray();
+
+                return typeInstructions;
+            }
+        }
+
+        static IReadOnlyCollection<Instruction> GetStateMachineInstructions(Type type)
+        {
+            var typeDefinition = TypeDefinitionsByType.GetOrAdd(type, GetTypeDefinitionFor);
+
+            lock (CecilMutex)
+            {
+                var stateMachineInstructions =
+                    typeDefinition
+                        .Methods
+                        .Where(x => x.HasAttribute<AsyncStateMachineAttribute>())
+                        .SelectMany(x => x.GetAsyncStateMachineType().Methods.Where(method => method.HasBody))
+                        .SelectMany(method => method.Body.Instructions)
+                        .Union(
+                            typeDefinition
+                                .Methods
+                                .Where(x => x.HasAttribute<IteratorStateMachineAttribute>())
+                                .SelectMany(x => x.GetIteratorStateMachineType().Methods.Where(method => method.HasBody))
+                                .SelectMany(method => method.Body.Instructions))
+                        .Distinct()
+                        .ToArray();
+
+                return stateMachineInstructions;
+            }
+        }
+
+        public static MethodDefinition GetMethodDefinitionFor(MethodInfo method)
+        {
+            var typeDefinition = GetTypeDefinitionFor(method.DeclaringType!);
+
+            //TODO This isn't an exact match. Please feel free to tighten the criteria if you need to.  -andrewh 22/9/2021
+            var methodDefinition = typeDefinition.Methods
+                .Where(m => m.Name == method.Name)
+                .First(m => m.Parameters.Count == method.GetParameters().Length);
+            return methodDefinition;
+        }
+
+        public static TypeDefinition GetTypeDefinitionFor(Type type)
+        {
+            if (type.IsNested && type.DeclaringType != null)
+            {
+                var parentTypeDefinition = GetTypeDefinitionFor(type.DeclaringType);
+
+                // ReSharper disable once ReplaceWithSingleCallToSingleOrDefault
+                var typeDefinition = parentTypeDefinition.NestedTypes.Where(td => td.Name == type.Name).SingleOrDefault()
+                    ?? throw new Exception($"Could not find nested type {type.Name} in declaring type {parentTypeDefinition.FullName}");
+
+                return typeDefinition;
+            }
+
+            var result = TypeDefinitionsByType.GetOrAdd(
+                type,
+                t =>
+                {
+                    var moduleDefinition = ModuleDefinitionsByAssemblyLocation.GetOrAdd(t.Assembly.Location, GetModuleDefinitionByLocation);
+                    var typeDefinition = (TypeDefinition)moduleDefinition.GetType(type.FullName, true);
+                    if (typeDefinition is null)
+                    {
+                        var additionalMessage = 
+                            string.Join(
+                                Environment.NewLine, 
+                                moduleDefinition.Types.Select(td => $" - {td.FullName}"));
+                        
+                        throw new InvalidOperationException($"Could not find type {t.FullName} in {t.Assembly.Location}.{Environment.NewLine}Types we can see: {additionalMessage}");
+                    }
+
+                    return typeDefinition;
+                });
+
+            return result;
+        }
+
+        static ModuleDefinition GetModuleDefinitionByLocation(string location)
+        {
+            var moduleDefinition = ModuleDefinition.ReadModule(
+                location,
+                new ReaderParameters
+                {
+                    AssemblyResolver = new ConventionalAssemblyResolver()
+                });
+
+            return moduleDefinition;
+        }
+    }
+}

--- a/src/Core/Conventional/Conventions/Cecil/DecompilationCache.cs
+++ b/src/Core/Conventional/Conventions/Cecil/DecompilationCache.cs
@@ -15,7 +15,7 @@ namespace Conventional.Conventions.Cecil
         static readonly ConcurrentDictionary<Type, TypeDefinition> TypeDefinitionsByType;
         static readonly ConcurrentDictionary<Type, IReadOnlyCollection<Instruction>> InstructionsByType;
         static readonly ConcurrentDictionary<Type, IReadOnlyCollection<Instruction>> StateMachineInstructionsByType;
-        static readonly object CecilMutex; // Cecil is not internally thread-safe in some places
+        static readonly object CecilMutex; // Note: Cecil is not internally thread-safe in some places
 
         static DecompilationCache()
         {
@@ -90,7 +90,7 @@ namespace Conventional.Conventions.Cecil
         {
             var typeDefinition = GetTypeDefinitionFor(method.DeclaringType!);
 
-            //TODO This isn't an exact match. Please feel free to tighten the criteria if you need to.  -andrewh 22/9/2021
+            // Note: This isn't an exact match. 
             var methodDefinition = typeDefinition.Methods
                 .Where(m => m.Name == method.Name)
                 .First(m => m.Parameters.Count == method.GetParameters().Length);
@@ -103,9 +103,8 @@ namespace Conventional.Conventions.Cecil
             {
                 var parentTypeDefinition = GetTypeDefinitionFor(type.DeclaringType);
 
-                // ReSharper disable once ReplaceWithSingleCallToSingleOrDefault
-                var typeDefinition = parentTypeDefinition.NestedTypes.Where(td => td.Name == type.Name).SingleOrDefault()
-                    ?? throw new Exception($"Could not find nested type {type.Name} in declaring type {parentTypeDefinition.FullName}");
+                var typeDefinition = parentTypeDefinition.NestedTypes.SingleOrDefault(td => td.Name == type.Name)
+                                     ?? throw new Exception($"Could not find nested type {type.Name} in declaring type {parentTypeDefinition.FullName}");
 
                 return typeDefinition;
             }

--- a/src/Core/Conventional/Conventions/Cecil/ExceptionsThrownMustBeDerivedFrom.cs
+++ b/src/Core/Conventional/Conventions/Cecil/ExceptionsThrownMustBeDerivedFrom.cs
@@ -18,7 +18,7 @@ namespace Conventional.Conventions.Cecil
 
         public override ConventionResult IsSatisfiedBy(Type type)
         {
-            var methodsWithBodies = type.ToTypeDefinition().Methods.Where(method => method.HasBody).ToList();
+            var methodsWithBodies = DecompilationCache.GetTypeDefinitionFor(type).Methods.Where(method => method.HasBody).ToList();
 
             var exceptions =
                 methodsWithBodies.SelectMany(method => method.Body.Instructions

--- a/src/Core/Conventional/Conventions/Cecil/LibraryCodeShouldCallConfigureAwaitWhenAwaitingTasksConventionSpecification.cs
+++ b/src/Core/Conventional/Conventions/Cecil/LibraryCodeShouldCallConfigureAwaitWhenAwaitingTasksConventionSpecification.cs
@@ -12,7 +12,7 @@ namespace Conventional.Conventions.Cecil
 
         public override ConventionResult IsSatisfiedBy(Type type)
         {
-            var failures = type.ToTypeDefinition()
+            var failures = DecompilationCache.GetTypeDefinitionFor(type)
                 .Methods
                 .Where(x => x.HasAttribute<AsyncStateMachineAttribute>())
                 .Where(AwaitingTasksWithoutConfigureAwait)

--- a/src/Core/Conventional/Conventions/Cecil/MustInstantiatePropertiesOfSpecifiedTypeInDefaultConstructor.cs
+++ b/src/Core/Conventional/Conventions/Cecil/MustInstantiatePropertiesOfSpecifiedTypeInDefaultConstructor.cs
@@ -23,7 +23,7 @@ namespace Conventional.Conventions.Cecil
 
         public override ConventionResult IsSatisfiedBy(Type type)
         {
-            var typeDefinition = type.ToTypeDefinition();
+            var typeDefinition = DecompilationCache.GetTypeDefinitionFor(type);
 
             var subjects = _propertyTypes.SelectMany(x => typeDefinition.GetPropertiesOfType(x));
 

--- a/src/Core/Conventional/Conventions/Cecil/MustNotResolveCurrentTimeViaDateTimeConventionSpecification.cs
+++ b/src/Core/Conventional/Conventions/Cecil/MustNotResolveCurrentTimeViaDateTimeConventionSpecification.cs
@@ -11,7 +11,7 @@ namespace Conventional.Conventions.Cecil
                 x=>DateTime.Now,
                 x=>DateTime.UtcNow,
                 x=>DateTime.Today
-            }, "Must not use DateTime directly. It is used {0} times in {1}. ")
+            })
         {
 
         }

--- a/src/Core/Conventional/Conventions/Cecil/MustNotUseDateTimeOffsetNowConventionSpecification.cs
+++ b/src/Core/Conventional/Conventions/Cecil/MustNotUseDateTimeOffsetNowConventionSpecification.cs
@@ -6,7 +6,7 @@ namespace Conventional.Conventions.Cecil
     public class MustNotUseDateTimeOffsetNowConventionSpecification : MustNotUsePropertyGetterSpecification<DateTimeOffset, DateTimeOffset>
     {
         public MustNotUseDateTimeOffsetNowConventionSpecification()
-            : base(new Expression<Func<DateTimeOffset, DateTimeOffset>>[] { x => DateTimeOffset.Now, x=>DateTimeOffset.UtcNow}, "Must not use DateTimeOffset.Now or DateTimeOffset.UtcNow. It is called {0} times in this type.")
+            : base(new Expression<Func<DateTimeOffset, DateTimeOffset>>[] { x => DateTimeOffset.Now, x=>DateTimeOffset.UtcNow})
         {
         }
     }

--- a/src/Core/Conventional/Conventions/Cecil/MustNotUseMethodSpecification.cs
+++ b/src/Core/Conventional/Conventions/Cecil/MustNotUseMethodSpecification.cs
@@ -60,7 +60,7 @@ namespace Conventional.Conventions.Cecil
         static string ToFullyQualifiedName(MethodReference method)
         {
             var declaringType = method.DeclaringType;
-            var typeFullName = $"{declaringType.Namespace}.{declaringType.Name}"; // Flatten generic type names. This is a lossy operation.
+            var typeFullName = $"{declaringType.Namespace}.{declaringType.Name}"; // Note: Flatten generic type names. This is a lossy operation.
             return $"{typeFullName}.{method.Name}";
         }
     }

--- a/src/Core/Conventional/Conventions/Cecil/MustNotUsePropertyGetterSpecification.cs
+++ b/src/Core/Conventional/Conventions/Cecil/MustNotUsePropertyGetterSpecification.cs
@@ -5,16 +5,15 @@ using System.Reflection;
 
 namespace Conventional.Conventions.Cecil
 {
-    public abstract class MustNotUsePropertyGetterSpecification<TClass, TMember> : MustNotUseMethodSpecification
+    public abstract class MustNotUsePropertyGetterSpecification<TClass, TMember> : MustNotCallMethodConventionSpecification
     {
-        public MustNotUsePropertyGetterSpecification(Expression<Func<TClass, TMember>> expression,
-            string failureMessage)
-            :this(new[] {expression},failureMessage)
+        public MustNotUsePropertyGetterSpecification(Expression<Func<TClass, TMember>> expression)
+            : this(new[] {expression})
         {
         }
 
-        public MustNotUsePropertyGetterSpecification(Expression<Func<TClass, TMember>>[] expressions, string failureMessage):base(
-            expressions.Select(GetMethodInfoFromExpression).ToArray(), failureMessage)
+        public MustNotUsePropertyGetterSpecification(Expression<Func<TClass, TMember>>[] expressions):base(
+            expressions.Select(GetMethodInfoFromExpression).ToArray())
         {
         }
 


### PR DESCRIPTION
It can be very expensive to convert types to type definitions when applying Cecil conventions.

This can lead to convention tests taking minutes upon minutes in larger codebases.

This PR introduces a `DecompilationCache` which can be used to cache type definitions, to speed up cecil-based conventions.