### PR TITLE
Best.Conventional.Roslyn upgrade

### DIFF
--- a/src/Roslyn/Conventional.Roslyn.Analyzers/Conventional.Roslyn.Analyzers.csproj
+++ b/src/Roslyn/Conventional.Roslyn.Analyzers/Conventional.Roslyn.Analyzers.csproj
@@ -5,8 +5,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.5.0" />
-      <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.5.0" />
+      <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.7.0" />
+      <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.7.0" />
     </ItemGroup>
 
 </Project>

--- a/src/Roslyn/Conventional.Roslyn.Analyzers/Conventional.Roslyn.Analyzers.csproj
+++ b/src/Roslyn/Conventional.Roslyn.Analyzers/Conventional.Roslyn.Analyzers.csproj
@@ -5,8 +5,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="3.6.0" />
-      <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.6.0" />
+      <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="[4.0.1,)" />
+      <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="[4.0.1,)" />
     </ItemGroup>
 
 </Project>

--- a/src/Roslyn/Conventional.Roslyn.Analyzers/Conventional.Roslyn.Analyzers.csproj
+++ b/src/Roslyn/Conventional.Roslyn.Analyzers/Conventional.Roslyn.Analyzers.csproj
@@ -5,8 +5,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="[4.0.1,)" />
-      <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="[4.0.1,)" />
+      <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.5.0" />
+      <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.5.0" />
     </ItemGroup>
 
 </Project>

--- a/src/Roslyn/Conventional.Roslyn.Tests/Conventional.Roslyn.Tests.csproj
+++ b/src/Roslyn/Conventional.Roslyn.Tests/Conventional.Roslyn.Tests.csproj
@@ -2,12 +2,17 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Best.Conventional" Version="9.0.3" />
+        <PackageReference Include="Best.Conventional" Version="11.0.0" />
         <PackageReference Include="FluentAssertions" Version="4.19.4" />
+        <PackageReference Include="Microsoft.Build.Locator" Version="1.6.10" />
+        <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.7.0" />
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.7.0" />
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.7.0" />
+        <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.7.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
         <PackageReference Include="NUnit" Version="3.12.0" />
         <PackageReference Include="NUnit3TestAdapter" Version="3.16.0" />

--- a/src/Roslyn/Conventional.Roslyn/Conventional.Roslyn.csproj
+++ b/src/Roslyn/Conventional.Roslyn/Conventional.Roslyn.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <PackageId>Best.Conventional.Roslyn</PackageId>
         <Title>Best.Conventional.Roslyn</Title>
         <Authors>Andrew Best</Authors>
@@ -17,10 +17,10 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Best.Conventional" Version="9.0.3" />
-      <PackageReference Include="Microsoft.Build.Locator" Version="1.2.6" />
-      <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.6.0" />
-      <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="3.6.0" />
+      <PackageReference Include="Best.Conventional" Version="[9.0.3,)" />
+      <PackageReference Include="Microsoft.Build.Locator" Version="[1.2.2,)" />
+      <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="[4.0.1,)" />
+      <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="[4.0.1,)" />
     </ItemGroup>
 
     <ItemGroup>
@@ -30,6 +30,21 @@
     <ItemGroup>
         <None Update="tools\*.ps1" CopyToOutputDirectory="Always" Pack="true" PackagePath="tools" />
         <None Include="$(OutputPath)\Conventional.Roslyn.Analyzers.dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
+        
     </ItemGroup>
+
+    <PropertyGroup>
+        <TargetsForTfmSpecificBuildOutput> $(TargetsForTfmSpecificBuildOutput);CopyProjectReferencesToPackage</TargetsForTfmSpecificBuildOutput>
+    </PropertyGroup>
+
+    <Target Name="CopyProjectReferencesToPackage" DependsOnTargets="BuildOnlySettings;ResolveReferences">
+        <ItemGroup>
+            <_ReferenceCopyLocalPaths Include="@(ReferenceCopyLocalPaths->WithMetadataValue('ReferenceSourceTarget', 'ProjectReference')->WithMetadataValue('PrivateAssets', 'All'))"/>
+        </ItemGroup>
+
+        <ItemGroup>
+            <BuildOutputInPackage Include="@(_ReferenceCopyLocalPaths)" TargetPath="%(_ReferenceCopyLocalPaths.DestinationSubDirectory)"/>
+        </ItemGroup>
+    </Target>
 
 </Project>

--- a/src/Roslyn/Conventional.Roslyn/Conventional.Roslyn.csproj
+++ b/src/Roslyn/Conventional.Roslyn/Conventional.Roslyn.csproj
@@ -19,8 +19,8 @@
     <ItemGroup>
       <PackageReference Include="Best.Conventional" Version="11.0.0" />
       <PackageReference Include="Microsoft.Build.Locator" Version="1.6.10" />
-      <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.5.0" />
-      <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.5.0" />
+      <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.7.0" />
+      <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.7.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Roslyn/Conventional.Roslyn/Conventional.Roslyn.csproj
+++ b/src/Roslyn/Conventional.Roslyn/Conventional.Roslyn.csproj
@@ -17,10 +17,10 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Best.Conventional" Version="[9.0.3,)" />
-      <PackageReference Include="Microsoft.Build.Locator" Version="[1.2.2,)" />
-      <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="[4.0.1,)" />
-      <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="[4.0.1,)" />
+      <PackageReference Include="Best.Conventional" Version="11.0.0" />
+      <PackageReference Include="Microsoft.Build.Locator" Version="1.6.10" />
+      <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.5.0" />
+      <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.5.0" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
- Upgrading target framework to latest LTS version
- Updating dependencies, making sure dependencies are not strict with minor versions and support wide range of variations on consumer side
- Including Conventional.Roslyn.Analyzers.dll as dependency in output nuget/lib/net6.0/ so that writing custom SolutionDiagnosticAnalyzerConventionSpecification is possible 
 as DiagnosticResult type is missing from public contract currently
 
![image](https://github.com/andrewabest/Conventional/assets/38276/fdc1eb05-89ce-4502-b67d-697d931482d2)


