### PR TITLE
Adds global type filtering configuration

### DIFF
--- a/src/Core/Conventional.Tests/ConventionConfigurationScenarios.cs
+++ b/src/Core/Conventional.Tests/ConventionConfigurationScenarios.cs
@@ -1,4 +1,5 @@
-﻿using NUnit.Framework;
+﻿using FluentAssertions;
+using NUnit.Framework;
 
 namespace Conventional.Tests
 {
@@ -8,8 +9,9 @@ namespace Conventional.Tests
         public void Setup()
         {
             ConventionConfiguration.DefaultFailureAssertionCallback = Assert.Pass;
+            ConventionConfiguration.GlobalTypeFilter = type => type != typeof(YouCantSeeMe);
         }
-
+        
         private class AbjectConformanceFailure
         {
             public AbjectConformanceFailure(string name, string description)
@@ -39,11 +41,30 @@ namespace Conventional.Tests
                         Convention.PropertiesMustHavePublicSetters.And(
                             Convention.MustHaveADefaultConstructor)));
         }
+        
+        private class YouCantSeeMe
+        {
+            public string Name { get; set; }
+        }
+
+        private class YouCanSeeMe
+        {
+            public string Name { get; set; }
+        }
+        
+        [Test]
+        public void WhenDefaultTypeFilterIsSet_ItIsAppliedToAllConventions()
+        {
+            new[] { typeof(YouCantSeeMe), typeof(YouCanSeeMe) }
+                .MustConformTo(Convention.PropertiesMustHavePrivateSetters)
+                .Failures.Should().HaveCount(1);
+        }
 
         [TearDown]
         public void TearDown()
         {
             ConventionConfiguration.DefaultFailureAssertionCallback = null;
+            ConventionConfiguration.ResetGlobalTypeFilter();
         }
     }
 }

--- a/src/Core/Conventional/AsyncConformist.cs
+++ b/src/Core/Conventional/AsyncConformist.cs
@@ -15,9 +15,11 @@ namespace Conventional
 
         public static async Task<WrappedConventionResult> MustConformTo(this IEnumerable<Type> types, IAsyncConventionSpecification conventionSpecification)
         {
+            var filteredTypes = types.Where(ConventionConfiguration.GlobalTypeFilter).ToArray();
+
             return Conformist.EnforceConformance(new WrappedConventionResult(
-                types,
-                await Task.WhenAll(types.Select(conventionSpecification.IsSatisfiedBy))));
+                filteredTypes,
+                await Task.WhenAll(filteredTypes.Select(conventionSpecification.IsSatisfiedBy))));
         }
 
         public static async Task<WrappedConventionResult> AndMustConformTo(this Task<WrappedConventionResult> results, IAsyncConventionSpecification conventionSpecification)

--- a/src/Core/Conventional/Conformist.cs
+++ b/src/Core/Conventional/Conformist.cs
@@ -15,9 +15,11 @@ namespace Conventional
 
         public static WrappedConventionResult MustConformTo(this IEnumerable<Type> types, IConventionSpecification conventionSpecification)
         {
+            var filteredTypes = types.Where(ConventionConfiguration.GlobalTypeFilter).ToArray();
+            
             return EnforceConformance(new WrappedConventionResult(
-                types, 
-                types.Select(conventionSpecification.IsSatisfiedBy)));
+                filteredTypes, 
+                filteredTypes.Select(conventionSpecification.IsSatisfiedBy)));
         }
 
         public static ConventionResult MustConformTo(this Assembly assembly, IAssemblyConventionSpecification assemblyConventionSpecification)

--- a/src/Core/Conventional/ConventionConfiguration.cs
+++ b/src/Core/Conventional/ConventionConfiguration.cs
@@ -7,5 +7,11 @@ namespace Conventional
         public static Action<string> DefaultFailureAssertionCallback { get; set; }
         public static Action<string> DefaultWarningAssertionCallback { get; set; }
         public static Func<DateTime> DefaultCurrentDateResolver { get; set; } = () => DateTime.UtcNow;
+        private static readonly Func<Type, bool> DefaultGlobalTypeFilter = t => true;
+        public static Func<Type, bool> GlobalTypeFilter { get; set; } = DefaultGlobalTypeFilter;
+        public static void ResetGlobalTypeFilter()
+        {
+            GlobalTypeFilter = DefaultGlobalTypeFilter;
+        }
     }
 }


### PR DESCRIPTION
In #82 we've discussed the need for global type filtering, where there are a known set of types that might exist that we _never_ want inspected for conventions.

These types might exist for a variety of reasons, that may be difficult to control. Rather than trying to control the presence or the validity of the types, we will simply provide a way to exclude them.

This PR introduces the agreed approach for excluding these types - a predicate that can be set via `ConventionConfiguration` called `GlobalTypeFilter`.