### PR TITLE
Additional features for Roslyn

### DIFF
--- a/src/Roslyn/Conventional.Roslyn.Analyzers/ConventionalSyntaxNodeAnalyzer.cs
+++ b/src/Roslyn/Conventional.Roslyn.Analyzers/ConventionalSyntaxNodeAnalyzer.cs
@@ -20,7 +20,7 @@ namespace Conventional.Roslyn.Analyzers
 
         void Analyze(SyntaxNodeAnalysisContext context)
         {
-            var result = CheckNode(context.Node);
+            var result = CheckNode(context.Node, context.SemanticModel);
 
             if (result.Success == false)
             {
@@ -34,6 +34,6 @@ namespace Conventional.Roslyn.Analyzers
 
         protected abstract DiagnosticDescriptor Rule { get; }
 
-        public abstract DiagnosticResult CheckNode(SyntaxNode node);
+        public abstract DiagnosticResult CheckNode(SyntaxNode node, SemanticModel semanticModel);
     }
 }

--- a/src/Roslyn/Conventional.Roslyn.Analyzers/IfAndElseMustHaveBracesAnalyzer.cs
+++ b/src/Roslyn/Conventional.Roslyn.Analyzers/IfAndElseMustHaveBracesAnalyzer.cs
@@ -15,7 +15,7 @@ namespace Conventional.Roslyn.Analyzers
             DiagnosticSeverity.Warning,
             true);
 
-        public override DiagnosticResult CheckNode(SyntaxNode node)
+        public override DiagnosticResult CheckNode(SyntaxNode node, SemanticModel semanticModel)
         {
             switch (node)
             {

--- a/src/Roslyn/Conventional.Roslyn.Analyzers/UsingsStatementsMustNotBeNestedAnalyzer.cs
+++ b/src/Roslyn/Conventional.Roslyn.Analyzers/UsingsStatementsMustNotBeNestedAnalyzer.cs
@@ -15,7 +15,7 @@ namespace Conventional.Roslyn.Analyzers
             DiagnosticSeverity.Warning,
             true);
 
-        public override DiagnosticResult CheckNode(SyntaxNode node)
+        public override DiagnosticResult CheckNode(SyntaxNode node, SemanticModel semanticModel)
         {
             if (node is NamespaceDeclarationSyntax)
             {

--- a/src/Roslyn/Conventional.Roslyn.Tests/Conventions/SolutionDiagnosticAnalyzerConventionSpecificationTests.cs
+++ b/src/Roslyn/Conventional.Roslyn.Tests/Conventions/SolutionDiagnosticAnalyzerConventionSpecificationTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using FluentAssertions;
 using NUnit.Framework;
 
@@ -6,6 +7,45 @@ namespace Conventional.Roslyn.Tests.Conventions
 {
     public class SolutionDiagnosticAnalyzerConventionSpecificationTests
     {
+        public SolutionDiagnosticAnalyzerConventionSpecificationTests()
+        {
+            if (true)
+                Console.WriteLine("Ignore Me - I need to be in the source code");
+        }
+
+        [Test]
+        public void KnownOffendersAreIgnored()
+        {
+            ThisCodebase
+                .MustConformTo(
+                    RoslynConvention.IfAndElseMustHaveBraces(), 1)
+                .All(x => x.IsSatisfied)
+                .Should()
+                .BeTrue();
+        }
+
+        [Test]
+        public void KnownOffenderFailTheResult()
+        {
+            ThisCodebase
+                .MustConformTo(
+                    RoslynConvention.IfAndElseMustHaveBraces(), 0)
+                .All(x => x.IsSatisfied)
+                .Should()
+                .BeFalse();
+        }
+
+                [Test]
+        public void WeirdKnownOffenderNumbersDontFailTheResult()
+        {
+            ThisCodebase
+                .MustConformTo(
+                    RoslynConvention.IfAndElseMustHaveBraces(), -42)
+                .All(x => x.IsSatisfied)
+                .Should()
+                .BeFalse();
+        }
+
         [Test]
         public void IfAndElseMustHaveBracesAnalyzer_Success()
         {
@@ -19,13 +59,14 @@ namespace Conventional.Roslyn.Tests.Conventions
             }
         }
 
+
         [Test]
         public void IfAndElseMustHaveBracesAnalyzer_FailsWhenIfBlockDoesNotHaveBrace()
         {
             using (new TestSolution("TestSolution"))
             {
                 ThisCodebase.MustConformTo(
-                    RoslynConvention.IfAndElseMustHaveBraces())
+                        RoslynConvention.IfAndElseMustHaveBraces())
                     .Where(x => x.IsSatisfied == false)
                     .Should()
                     .Contain(x => x.IsSatisfied == false && x.SubjectName.EndsWith("IfBracelessWonder.cs"));
@@ -38,7 +79,7 @@ namespace Conventional.Roslyn.Tests.Conventions
             using (new TestSolution("TestSolution"))
             {
                 ThisCodebase.MustConformTo(
-                    RoslynConvention.IfAndElseMustHaveBraces())
+                        RoslynConvention.IfAndElseMustHaveBraces())
                     .Should()
                     .Contain(x => x.IsSatisfied == false && x.SubjectName.EndsWith("ElseBracelessWonder.cs"));
             }
@@ -63,7 +104,7 @@ namespace Conventional.Roslyn.Tests.Conventions
             using (new TestSolution("TestSolution"))
             {
                 ThisCodebase.MustConformTo(
-                    RoslynConvention.UsingStatementsMustNotBeNested())
+                        RoslynConvention.UsingStatementsMustNotBeNested())
                     .Should()
                     .Contain(x => x.IsSatisfied == false && x.SubjectName.EndsWith("SplitNamespaces.cs"));
             }

--- a/src/Roslyn/Conventional.Roslyn.Tests/Conventions/SolutionDiagnosticAnalyzerConventionSpecificationTests.cs
+++ b/src/Roslyn/Conventional.Roslyn.Tests/Conventions/SolutionDiagnosticAnalyzerConventionSpecificationTests.cs
@@ -35,17 +35,6 @@ namespace Conventional.Roslyn.Tests.Conventions
                 .BeFalse();
         }
 
-                [Test]
-        public void WeirdKnownOffenderNumbersDontFailTheResult()
-        {
-            ThisCodebase
-                .MustConformTo(
-                    RoslynConvention.IfAndElseMustHaveBraces(), -42)
-                .All(x => x.IsSatisfied)
-                .Should()
-                .BeFalse();
-        }
-
         [Test]
         public void IfAndElseMustHaveBracesAnalyzer_Success()
         {

--- a/src/Roslyn/Conventional.Roslyn.Tests/DogFoodConventions.cs
+++ b/src/Roslyn/Conventional.Roslyn.Tests/DogFoodConventions.cs
@@ -11,12 +11,13 @@ namespace Conventional.Roslyn.Tests
         [Test]
         public void ConventionSpecifications_MustHaveNameThatEndsWithConventionSpecification()
         {
+            ConventionConfiguration.DefaultFailureAssertionCallback = Assert.Fail;
+            ConventionConfiguration.DefaultWarningAssertionCallback =  Assert.Inconclusive;
             var baseAssembly = typeof(RoslynConvention).Assembly;
 
             new[] { baseAssembly }
                 .WhereTypes(x => ConventionTypes.Any(c => c.IsAssignableFrom(x)) && x.IsAbstract == false)
-                .MustConformTo(Convention.NameMustEndWith("ConventionSpecification"))
-                .WithFailureAssertion(Assert.Fail);
+                .MustConformTo(Convention.NameMustEndWith("ConventionSpecification"));
         }
 
         private Type[] ConventionTypes => new[]

--- a/src/Roslyn/Conventional.Roslyn/Conventions/IfAndElseMustHaveBracesConventionSpecification.cs
+++ b/src/Roslyn/Conventional.Roslyn/Conventions/IfAndElseMustHaveBracesConventionSpecification.cs
@@ -16,9 +16,9 @@ namespace Conventional.Roslyn.Conventions
             _analyzer = new IfAndElseMustHaveBracesAnalyzer();
         }
 
-        protected override DiagnosticResult CheckNode(SyntaxNode node, Document document = null)
+        protected override DiagnosticResult CheckNode(SyntaxNode node, Document document = null, SemanticModel semanticModel = null)
         {
-            var result = _analyzer.CheckNode(node);
+            var result = _analyzer.CheckNode(node, semanticModel);
 
             if (result.Success == false)
             {

--- a/src/Roslyn/Conventional.Roslyn/Conventions/SolutionDiagnosticAnalyzerConventionSpecification.cs
+++ b/src/Roslyn/Conventional.Roslyn/Conventions/SolutionDiagnosticAnalyzerConventionSpecification.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using Conventional.Roslyn.Analyzers;
 using Microsoft.CodeAnalysis;
@@ -8,7 +7,7 @@ namespace Conventional.Roslyn.Conventions
 {
     public interface ISolutionDiagnosticAnalyzerConventionSpecification
     {
-        IEnumerable<ConventionResult> IsSatisfiedBy(Solution solution, int knownOffenders);
+        IEnumerable<ConventionResult> IsSatisfiedBy(Solution solution);
     }
 
     public abstract class SolutionDiagnosticAnalyzerConventionSpecification :
@@ -23,24 +22,12 @@ namespace Conventional.Roslyn.Conventions
             _fileExemptions = fileExemptions;
         }
 
-        public IEnumerable<ConventionResult> IsSatisfiedBy(Solution solution, int knownOffenders)
+        public IEnumerable<ConventionResult> IsSatisfiedBy(Solution solution)
         {
-            var results = solution.Projects.SelectMany(x => x.Documents
+            return solution.Projects.SelectMany(x => x.Documents
                     .Where(d => d.SupportsSyntaxTree)
                     .Where(d => !_fileExemptions.Any(d.FilePath.EndsWith)))
-                .SelectMany(IsSatisfiedBy)
-                .ToArray();
-            var filteredFailures = RemoveKnownOffenders(results, knownOffenders);
-            var final = results.Where(x => x.IsSatisfied).ToList();
-            final.AddRange(filteredFailures);
-
-            return final;
-        }
-
-        private static IEnumerable<ConventionResult> RemoveKnownOffenders(ConventionResult[] results, int knownOffenders)
-        {
-            var failures = results.Where(x => !x.IsSatisfied).ToArray();
-            return failures.Take(Math.Max(failures.Length - Math.Max(knownOffenders, 0), 0)).ToArray();
+                .SelectMany(IsSatisfiedBy);
         }
 
         private IEnumerable<ConventionResult> IsSatisfiedBy(Document document)

--- a/src/Roslyn/Conventional.Roslyn/Conventions/UsingsStatementsMustNotBeNestedConventionSpecification.cs
+++ b/src/Roslyn/Conventional.Roslyn/Conventions/UsingsStatementsMustNotBeNestedConventionSpecification.cs
@@ -16,9 +16,9 @@ namespace Conventional.Roslyn.Conventions
             _analyzer = new UsingsStatementsMustNotBeNestedAnalyzer();
         }
 
-        protected override DiagnosticResult CheckNode(SyntaxNode node, Document document = null)
+        protected override DiagnosticResult CheckNode(SyntaxNode node, Document document = null, SemanticModel semanticModel = null)
         {
-            var result = _analyzer.CheckNode(node);
+            var result = _analyzer.CheckNode(node, semanticModel);
 
             if (result.Success == false)
             {

--- a/src/Roslyn/Conventional.Roslyn/ThisCodebase.cs
+++ b/src/Roslyn/Conventional.Roslyn/ThisCodebase.cs
@@ -8,7 +8,7 @@ namespace Conventional.Roslyn
 {
     public static class ThisCodebase
     {
-        public static IEnumerable<ConventionResult> MustConformTo(ISolutionDiagnosticAnalyzerConventionSpecification convention)
+        public static IEnumerable<ConventionResult> MustConformTo(ISolutionDiagnosticAnalyzerConventionSpecification convention, int knownOffenders = 0)
         {
             // Locate and register the default instance of MSBuild installed on this machine.
             // https://github.com/dotnet/roslyn/issues/17974#issuecomment-624408861
@@ -21,13 +21,13 @@ namespace Conventional.Roslyn
 
             var solution = workspace.OpenSolutionAsync(KnownPaths.FullPathToSolution).Result;
 
-            foreach(var diagnostic in workspace.Diagnostics)
+            foreach (var diagnostic in workspace.Diagnostics)
             {
                 Trace.WriteLine(diagnostic.Message);
             }
 
             return Conformist.EnforceConformance(
-                convention.IsSatisfiedBy(solution));
+                convention.IsSatisfiedBy(solution, knownOffenders));
         }
     }
 }


### PR DESCRIPTION
# Description

I found the need to:
 - allow knownOffenders for a roslyn convention spec (usages of a class/method I no longer wish to allow)
 - expose the `SemanticModel` when processing `SyntaxNode`s

Imo, these would make a good/valuable addition to the library.

Let me know if this aligns with your thinking or have any ideas on how to make this better. :) I had the thought that we could modify the `Conformist.EnforceConformance`, but opted for the simpler change to get your thoughts.
