### PR TITLE
[GH-87] Adds Convention.NamespaceMustStartWith & Convention.Namespace.MustEndWith

### DIFF
--- a/src/Core/Conventional.Tests/Conventional/Conventions/ConventionSpecificationTests.cs
+++ b/src/Core/Conventional.Tests/Conventional/Conventions/ConventionSpecificationTests.cs
@@ -310,7 +310,7 @@ namespace Conventional.Tests.Conventional.Conventions
                 .Should()
                 .BeTrue();
         }
-        
+
         [Test]
         public void NameMustStartWithConventionSpecification_FailsIfNameDoesNotStartWithSuppliedPrefix()
         {
@@ -320,7 +320,7 @@ namespace Conventional.Tests.Conventional.Conventions
             result.IsSatisfied.Should().BeFalse();
             result.Failures.Should().HaveCount(1);
         }
-        
+
         private class ClassSuffix
         {
         }
@@ -334,7 +334,7 @@ namespace Conventional.Tests.Conventional.Conventions
                 .Should()
                 .BeTrue();
         }
-        
+
         [Test]
         public void NameMustEndWithConventionSpecification_FailsIfNameDoesNotEndWithSuppliedPrefix()
         {
@@ -382,6 +382,46 @@ namespace Conventional.Tests.Conventional.Conventions
         {
             var result = typeof (ClassSuffix)
                 .MustConformTo(Convention.MustLiveInNamespace("Another.Namespace"));
+
+            result.IsSatisfied.Should().BeFalse();
+            result.Failures.Should().HaveCount(1);
+        }
+
+        [Test]
+        public void NamespaceMustStartWithConventionSpecification_Success()
+        {
+            typeof(NamespaceMember)
+                .MustConformTo(Convention.NamespaceMustStartWith("Conventional.Tests.Conven"))
+                .IsSatisfied
+                .Should()
+                .BeTrue();
+        }
+
+        [Test]
+        public void NamespaceMustStartWithConventionSpecification_FailsIfTypeDoesNotLiveInANamespaceStartingWithPrefix()
+        {
+            var result = typeof (NamespaceMember)
+                .MustConformTo(Convention.NamespaceMustStartWith("Conventional.Potato"));
+
+            result.IsSatisfied.Should().BeFalse();
+            result.Failures.Should().HaveCount(1);
+        }
+
+        [Test]
+        public void NamespaceMustEndWithConventionSpecification_Success()
+        {
+            typeof(NamespaceMember)
+                .MustConformTo(Convention.NamespaceMustEndWith(".Conventional.Conventions"))
+                .IsSatisfied
+                .Should()
+                .BeTrue();
+        }
+
+        [Test]
+        public void NamespaceMustEndWithConventionSpecification_FailsIfTypeDoesNotLiveInANamespaceEndingWithSuffix()
+        {
+            var result = typeof (NamespaceMember)
+                .MustConformTo(Convention.NamespaceMustEndWith(".Conventional.Potato"));
 
             result.IsSatisfied.Should().BeFalse();
             result.Failures.Should().HaveCount(1);
@@ -477,7 +517,7 @@ namespace Conventional.Tests.Conventional.Conventions
             {
             }
         }
-        
+
         [Test]
         public void MustNotTakeADependencyOnConventionSpecification_FailsIfTheIdentifiedConstructorParameterExists()
         {
@@ -506,7 +546,7 @@ namespace Conventional.Tests.Conventional.Conventions
                  .MustConformTo(Convention.MustHaveAppropriateConstructors)
                  .IsSatisfied
                  .Should()
-                 .BeTrue(); 
+                 .BeTrue();
         }
 
         private class DoesNotHaveAppropriateConstructors
@@ -549,7 +589,7 @@ namespace Conventional.Tests.Conventional.Conventions
                  .MustConformTo(Convention.RequiresACorrespondingImplementationOf(typeof(SomeGeneric<,>), new [] { typeof(SomeGenericImplementation) }))
                  .IsSatisfied
                  .Should()
-                 .BeTrue(); 
+                 .BeTrue();
         }
 
         private interface ISomeGeneric<T1, T2>
@@ -694,7 +734,7 @@ namespace Conventional.Tests.Conventional.Conventions
 
         private class HasLazilyLoadedEnumerables
         {
-            public IEnumerable<string> Names { get; set; } 
+            public IEnumerable<string> Names { get; set; }
         }
 
         [Test]
@@ -767,8 +807,8 @@ namespace Conventional.Tests.Conventional.Conventions
 
             result.IsSatisfied.Should().BeFalse();
             result.Failures.Should().HaveCount(1);
-        } 
-        
+        }
+
         private class HasImmutableProperties
         {
             public HasImmutableProperties(string[] names, int age)

--- a/src/Core/Conventional/Convention.cs
+++ b/src/Core/Conventional/Convention.cs
@@ -30,7 +30,7 @@ namespace Conventional
         {
             return new NameMustStartWithConventionSpecification(prefix);
         }
-        
+
         public static NameMustEndWithConventionSpecification NameMustEndWith(string suffix)
         {
             return new NameMustEndWithConventionSpecification(suffix);
@@ -39,6 +39,16 @@ namespace Conventional
         public static MustLiveInNamespaceConventionSpecification MustLiveInNamespace(string nameSpace)
         {
             return new MustLiveInNamespaceConventionSpecification(nameSpace);
+        }
+
+        public static NamespaceMustStartWithConventionSpecification NamespaceMustStartWith(string prefix)
+        {
+            return new NamespaceMustStartWithConventionSpecification(prefix);
+        }
+
+        public static NamespaceMustEndWithConventionSpecification NamespaceMustEndWith(string suffix)
+        {
+            return new NamespaceMustEndWithConventionSpecification(suffix);
         }
 
         public static MustHaveADefaultConstructorConventionSpecification MustHaveADefaultConstructor => new MustHaveADefaultConstructorConventionSpecification();

--- a/src/Core/Conventional/Conventions/NamespaceMustEndWithConventionSpecification.cs
+++ b/src/Core/Conventional/Conventions/NamespaceMustEndWithConventionSpecification.cs
@@ -1,0 +1,23 @@
+﻿using System;
+
+namespace Conventional.Conventions
+{
+    public class NamespaceMustEndWithConventionSpecification : ConventionSpecification
+    {
+        private readonly string _namespaceSuffix;
+
+        public NamespaceMustEndWithConventionSpecification(string suffix) => _namespaceSuffix = suffix;
+
+        protected override string FailureMessage => "Must live in namespace ending with {0} but actually lives in namespace {1}";
+
+        public override ConventionResult IsSatisfiedBy(Type type)
+        {
+            if (type.Namespace != null && type.Namespace.EndsWith(_namespaceSuffix))
+            {
+                return ConventionResult.Satisfied(type.FullName);
+            }
+
+            return ConventionResult.NotSatisfied(type.FullName, FailureMessage.FormatWith(_namespaceSuffix, type.Namespace));
+        }
+    }
+}

--- a/src/Core/Conventional/Conventions/NamespaceMustStartWithConventionSpecification.cs
+++ b/src/Core/Conventional/Conventions/NamespaceMustStartWithConventionSpecification.cs
@@ -1,0 +1,23 @@
+﻿using System;
+
+namespace Conventional.Conventions
+{
+    public class NamespaceMustStartWithConventionSpecification : ConventionSpecification
+    {
+        private readonly string _namespacePrefix;
+
+        public NamespaceMustStartWithConventionSpecification(string prefix) => _namespacePrefix = prefix;
+
+        protected override string FailureMessage => "Must live in namespace beginning with {0} but actually lives in namespace {1}";
+
+        public override ConventionResult IsSatisfiedBy(Type type)
+        {
+            if (type.Namespace != null && type.Namespace.StartsWith(_namespacePrefix))
+            {
+                return ConventionResult.Satisfied(type.FullName);
+            }
+
+            return ConventionResult.NotSatisfied(type.FullName, FailureMessage.FormatWith(_namespacePrefix, type.Namespace));
+        }
+    }
+}


### PR DESCRIPTION
These were discussed (see GH-87) but not implemented under pull-request GH-90 because I thought they already existed 🤦‍♂️ 

Currently (as of 11.0.11) there's only
- `Convention.NameMustStartWith` / `Convention.NameMustEndWith` (which only consider the _immediate_ type name, not `FullName`) and
- `Convention.MustLiveInNamespace` (which doesn't support a prefix/suffix/regex)
