### PR TITLE
Fix: Use GetSemanticModelAsync instead of TryGetSemanticModel to make available the SemanticModel in Roslyn conventions

### DIFF
--- a/src/Roslyn/Conventional.Roslyn/Conventions/SolutionDiagnosticAnalyzerConventionSpecification.cs
+++ b/src/Roslyn/Conventional.Roslyn/Conventions/SolutionDiagnosticAnalyzerConventionSpecification.cs
@@ -33,7 +33,8 @@ namespace Conventional.Roslyn.Conventions
         private IEnumerable<ConventionResult> IsSatisfiedBy(Document document)
         {
             var node = document.GetSyntaxRootAsync().Result;
-            if (document.TryGetSemanticModel(out var semanticModel))
+            var semanticModel = document.GetSemanticModelAsync().Result;
+            if (semanticModel is not null)
             {
                 return IsSatisfiedBy(document, node, semanticModel);
             }

--- a/src/Roslyn/Conventional.Roslyn/Conventions/SolutionDiagnosticAnalyzerConventionSpecification.cs
+++ b/src/Roslyn/Conventional.Roslyn/Conventions/SolutionDiagnosticAnalyzerConventionSpecification.cs
@@ -33,7 +33,7 @@ namespace Conventional.Roslyn.Conventions
         private IEnumerable<ConventionResult> IsSatisfiedBy(Document document)
         {
             var node = document.GetSyntaxRootAsync().Result;
-            var semanticModel = document.GetSemanticModelAsync().Result;
+            var semanticModel = document.GetSemanticModelAsync().GetAwaiter().GetResult();
             if (semanticModel is not null)
             {
                 return IsSatisfiedBy(document, node, semanticModel);


### PR DESCRIPTION
## Description

This PR swaps `document.TryGetSemanticModel` for `semanticModel = document.GetSemanticModelAsync().Result`.

This PR is based on the details provided in this related issue: https://github.com/andrewabest/Conventional/issues/94
There is a reproduction if this issue linked in the issue.

The summary is: `TryGetSemanticModel` doesn't seem to work as expected. Testing indicates that `GetSemanticModelAsync` may be a suitable alternative.