### PR TITLE
Add basic parallel.foreach to speed up processing documents in Roslyn Conventions

### DIFF
--- a/src/Roslyn/Conventional.Roslyn.Analyzers/ConventionalSyntaxNodeAnalyzer.cs
+++ b/src/Roslyn/Conventional.Roslyn.Analyzers/ConventionalSyntaxNodeAnalyzer.cs
@@ -12,8 +12,13 @@ namespace Conventional.Roslyn.Analyzers
     {
         public override void Initialize(AnalysisContext context)
         {
-            context.RegisterSyntaxNodeAction(Analyze, SyntaxKind.IfStatement, SyntaxKind.ElseClause);
-            context.EnableConcurrentExecution();
+            context.RegisterSyntaxNodeAction(Analyze, SyntaxKinds());
+
+            if (EnableConcurrentExecution())
+            {
+                context.EnableConcurrentExecution();
+            }
+
             // Generate diagnostic reports, but do not allow analyzer actions
             context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.ReportDiagnostics);
         }
@@ -35,5 +40,7 @@ namespace Conventional.Roslyn.Analyzers
         protected abstract DiagnosticDescriptor Rule { get; }
 
         public abstract DiagnosticResult CheckNode(SyntaxNode node, SemanticModel semanticModel);
+        public abstract SyntaxKind[] SyntaxKinds();
+        public virtual bool EnableConcurrentExecution() => false;
     }
 }

--- a/src/Roslyn/Conventional.Roslyn.Analyzers/ConventionalSyntaxNodeAnalyzer.cs
+++ b/src/Roslyn/Conventional.Roslyn.Analyzers/ConventionalSyntaxNodeAnalyzer.cs
@@ -13,26 +13,23 @@ namespace Conventional.Roslyn.Analyzers
         public override void Initialize(AnalysisContext context)
         {
             context.RegisterSyntaxNodeAction(Analyze, SyntaxKinds());
-
-            if (EnableConcurrentExecution())
-            {
-                context.EnableConcurrentExecution();
-            }
+            context.EnableConcurrentExecution();
 
             // Generate diagnostic reports, but do not allow analyzer actions
             context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.ReportDiagnostics);
         }
 
-        void Analyze(SyntaxNodeAnalysisContext context)
+        private void Analyze(SyntaxNodeAnalysisContext context)
         {
             var result = CheckNode(context.Node, context.SemanticModel);
 
-            if (result.Success == false)
+            if (result.Success)
             {
-                var loc = context.Node.GetLocation();
-                var diagnostic = Diagnostic.Create(Rule, loc, $"{result.Message} must have braces");
-                context.ReportDiagnostic(diagnostic);
+                return;
             }
+            var loc = context.Node.GetLocation();
+            var diagnostic = Diagnostic.Create(Rule, loc, $"{result.Message} must have braces");
+            context.ReportDiagnostic(diagnostic);
         }
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
@@ -41,6 +38,5 @@ namespace Conventional.Roslyn.Analyzers
 
         public abstract DiagnosticResult CheckNode(SyntaxNode node, SemanticModel semanticModel);
         public abstract SyntaxKind[] SyntaxKinds();
-        public virtual bool EnableConcurrentExecution() => false;
     }
 }

--- a/src/Roslyn/Conventional.Roslyn.Analyzers/IfAndElseMustHaveBracesAnalyzer.cs
+++ b/src/Roslyn/Conventional.Roslyn.Analyzers/IfAndElseMustHaveBracesAnalyzer.cs
@@ -30,6 +30,5 @@ namespace Conventional.Roslyn.Analyzers
         }
 
         public override SyntaxKind[] SyntaxKinds() => new[] { SyntaxKind.IfStatement, SyntaxKind.ElseClause };
-        public override bool EnableConcurrentExecution() => true;
     }
 }

--- a/src/Roslyn/Conventional.Roslyn.Analyzers/IfAndElseMustHaveBracesAnalyzer.cs
+++ b/src/Roslyn/Conventional.Roslyn.Analyzers/IfAndElseMustHaveBracesAnalyzer.cs
@@ -28,5 +28,8 @@ namespace Conventional.Roslyn.Analyzers
                     return DiagnosticResult.Succeeded();
             }
         }
+
+        public override SyntaxKind[] SyntaxKinds() => new[] { SyntaxKind.IfStatement, SyntaxKind.ElseClause };
+        public override bool EnableConcurrentExecution() => true;
     }
 }

--- a/src/Roslyn/Conventional.Roslyn.Analyzers/UsingsStatementsMustNotBeNestedAnalyzer.cs
+++ b/src/Roslyn/Conventional.Roslyn.Analyzers/UsingsStatementsMustNotBeNestedAnalyzer.cs
@@ -1,5 +1,7 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 
@@ -28,5 +30,8 @@ namespace Conventional.Roslyn.Analyzers
 
             return DiagnosticResult.Succeeded();
         }
+
+        public override SyntaxKind[] SyntaxKinds() => Array.Empty<SyntaxKind>();
+        public override bool EnableConcurrentExecution() => true;
     }
 }

--- a/src/Roslyn/Conventional.Roslyn.Analyzers/UsingsStatementsMustNotBeNestedAnalyzer.cs
+++ b/src/Roslyn/Conventional.Roslyn.Analyzers/UsingsStatementsMustNotBeNestedAnalyzer.cs
@@ -32,6 +32,5 @@ namespace Conventional.Roslyn.Analyzers
         }
 
         public override SyntaxKind[] SyntaxKinds() => Array.Empty<SyntaxKind>();
-        public override bool EnableConcurrentExecution() => true;
     }
 }

--- a/src/Roslyn/Conventional.Roslyn.Tests/Conventions/SolutionDiagnosticAnalyzerConventionSpecificationTests.cs
+++ b/src/Roslyn/Conventional.Roslyn.Tests/Conventions/SolutionDiagnosticAnalyzerConventionSpecificationTests.cs
@@ -48,7 +48,6 @@ namespace Conventional.Roslyn.Tests.Conventions
             }
         }
 
-
         [Test]
         public void IfAndElseMustHaveBracesAnalyzer_FailsWhenIfBlockDoesNotHaveBrace()
         {
@@ -88,7 +87,7 @@ namespace Conventional.Roslyn.Tests.Conventions
         }
 
         [Test]
-        public void UsingStatementsMustNotBeNestedAnalyzer_FailesWhenFileHasUsingsInsideNamespace()
+        public void UsingStatementsMustNotBeNestedAnalyzer_FailsWhenFileHasUsingsInsideNamespace()
         {
             using (new TestSolution("TestSolution"))
             {

--- a/src/Roslyn/Conventional.Roslyn/Conventions/IfAndElseMustHaveBracesConventionSpecification.cs
+++ b/src/Roslyn/Conventional.Roslyn/Conventions/IfAndElseMustHaveBracesConventionSpecification.cs
@@ -1,24 +1,20 @@
 using System.Linq;
 using Conventional.Roslyn.Analyzers;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace Conventional.Roslyn.Conventions
 {
-    [DiagnosticAnalyzer(LanguageNames.CSharp)]
     public class IfAndElseMustHaveBracesConventionSpecification : SolutionDiagnosticAnalyzerConventionSpecification
     {
-        private readonly IfAndElseMustHaveBracesAnalyzer _analyzer;
         protected override string FailureMessage => "If and else must have braces, and {0} statement on line {1} does not";
 
-        public IfAndElseMustHaveBracesConventionSpecification(string[] fileExemptions) : base(fileExemptions)
+        public IfAndElseMustHaveBracesConventionSpecification(string[] fileExemptions) : base(new IfAndElseMustHaveBracesAnalyzer(), fileExemptions)
         {
-            _analyzer = new IfAndElseMustHaveBracesAnalyzer();
         }
 
         protected override DiagnosticResult CheckNode(SyntaxNode node, Document document = null, SemanticModel semanticModel = null)
         {
-            var result = _analyzer.CheckNode(node, semanticModel);
+            var result = Analyzer.CheckNode(node, semanticModel);
 
             if (result.Success == false)
             {

--- a/src/Roslyn/Conventional.Roslyn/Conventions/SolutionDiagnosticAnalyzerConventionSpecification.cs
+++ b/src/Roslyn/Conventional.Roslyn/Conventions/SolutionDiagnosticAnalyzerConventionSpecification.cs
@@ -1,7 +1,9 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Conventional.Roslyn.Analyzers;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 
 namespace Conventional.Roslyn.Conventions
 {
@@ -10,25 +12,42 @@ namespace Conventional.Roslyn.Conventions
         IEnumerable<ConventionResult> IsSatisfiedBy(Solution solution);
     }
 
-    public abstract class SolutionDiagnosticAnalyzerConventionSpecification :
-        ISolutionDiagnosticAnalyzerConventionSpecification
+    public abstract class SolutionDiagnosticAnalyzerConventionSpecification : ISolutionDiagnosticAnalyzerConventionSpecification
     {
         // ReSharper disable once UnusedMemberInSuper.Global
         protected abstract string FailureMessage { get; }
+        protected readonly ConventionalSyntaxNodeAnalyzer Analyzer;
         private readonly string[] _fileExemptions;
 
-        protected SolutionDiagnosticAnalyzerConventionSpecification(string[] fileExemptions)
+        protected SolutionDiagnosticAnalyzerConventionSpecification(ConventionalSyntaxNodeAnalyzer diagnosticAnalyzer, string[] fileExemptions)
         {
+            Analyzer = diagnosticAnalyzer;
             _fileExemptions = fileExemptions;
         }
 
         public IEnumerable<ConventionResult> IsSatisfiedBy(Solution solution)
         {
-            return solution.Projects.SelectMany(x => x.Documents
-                    .Where(d => d.SupportsSyntaxTree)
-                    .Where(d => !_fileExemptions.Any(d.FilePath.EndsWith)))
-                .SelectMany(IsSatisfiedBy);
+            if (Analyzer.EnableConcurrentExecution())
+            {
+                var tasks = solution
+                    .Projects.SelectMany(x =>
+                        x.Documents
+                            .Where(d => d.SupportsSyntaxTree)
+                            .Where(FilterFileExceptions)
+                            .Select(doc => Task.Run(() => IsSatisfiedBy(doc))));
+                var result = Task.WhenAll(tasks).GetAwaiter().GetResult();
+                return result.SelectMany(x => x);
+            }
+
+            return solution
+                .Projects.SelectMany(x =>
+                    x.Documents
+                        .Where(d => d.SupportsSyntaxTree)
+                        .Where(FilterFileExceptions)
+                        .SelectMany(IsSatisfiedBy));
         }
+
+        private bool FilterFileExceptions(Document document) => !_fileExemptions.Any(exemption => document.FilePath?.EndsWith(exemption) ?? true);
 
         private IEnumerable<ConventionResult> IsSatisfiedBy(Document document)
         {
@@ -56,6 +75,9 @@ namespace Conventional.Roslyn.Conventions
 
         private ConventionResult BuildResult(Document document, SyntaxNode node, SemanticModel semanticModel)
         {
+            var kinds = Analyzer.SyntaxKinds();
+            if (kinds.Length > 0 && !kinds.Contains(node!.Kind())) return ConventionResult.Satisfied(document.FilePath);
+
             var result = CheckNode(node, document, semanticModel);
 
             return result.Success

--- a/src/Roslyn/Conventional.Roslyn/Conventions/UsingsStatementsMustNotBeNestedConventionSpecification.cs
+++ b/src/Roslyn/Conventional.Roslyn/Conventions/UsingsStatementsMustNotBeNestedConventionSpecification.cs
@@ -1,24 +1,20 @@
 ﻿using System.Linq;
 using Conventional.Roslyn.Analyzers;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace Conventional.Roslyn.Conventions
 {
-    [DiagnosticAnalyzer(LanguageNames.CSharp)]
     public class UsingsStatementsMustNotBeNestedConventionSpecification : SolutionDiagnosticAnalyzerConventionSpecification
     {
-        private readonly UsingsStatementsMustNotBeNestedAnalyzer _analyzer;
         protected override string FailureMessage => "{0} statements must not be nested within the namespace, using on line {1} does not conform";
 
-        public UsingsStatementsMustNotBeNestedConventionSpecification(string[] fileExemptions) : base(fileExemptions)
+        public UsingsStatementsMustNotBeNestedConventionSpecification(string[] fileExemptions) : base(new UsingsStatementsMustNotBeNestedAnalyzer(), fileExemptions)
         {
-            _analyzer = new UsingsStatementsMustNotBeNestedAnalyzer();
         }
 
         protected override DiagnosticResult CheckNode(SyntaxNode node, Document document = null, SemanticModel semanticModel = null)
         {
-            var result = _analyzer.CheckNode(node, semanticModel);
+            var result = Analyzer.CheckNode(node, semanticModel);
 
             if (result.Success == false)
             {


### PR DESCRIPTION
# Description

In large codebases, there can be hundreds of thousands of unfiltered syntax nodes to iterate over when processing solution documents. This can take over a minute when applying a roslyn convention in a test.

Despite the extension of the DiagnosticAnalyzer class, it appears that the syntax tree filtering that typically happens when applying diagnostic analyzers does not seem to happen when applying these analyzers manually. The result is that the entire syntax tree is provided to the framework.

This PR implements a naive parallel.foreach to process the syntax tree more quickly.

## Alternatives

- If we can find a way to apply the node type filters via conventional - that should be the approach
- Barring that, if there is a preferred parallelization approach - I'd be happy to go with that
