### PR TITLE
Downgrade Best.Conventional to target netstandard20 (rather than netstandard21 which excludes .NET Framework consumption)

### DIFF
--- a/src/Core/Conventional.Tests/Conventional.Tests.csproj
+++ b/src/Core/Conventional.Tests/Conventional.Tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <Version>0.0.0.0</Version>
   </PropertyGroup>
 

--- a/src/Core/Conventional.Tests/Conventional.Tests.csproj
+++ b/src/Core/Conventional.Tests/Conventional.Tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Version>0.0.0.0</Version>
   </PropertyGroup>
 

--- a/src/Core/Conventional.Tests/Conventional/Conventions/ConventionSpecificationTests.cs
+++ b/src/Core/Conventional.Tests/Conventional/Conventions/ConventionSpecificationTests.cs
@@ -847,7 +847,7 @@ namespace Conventional.Tests.Conventional.Conventions
 
             public string[] Names { get; }
 
-            public int Age { get; }
+            public new int Age { get; }
         }
 
         [Test]

--- a/src/Core/Conventional/Conventional.csproj
+++ b/src/Core/Conventional/Conventional.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <PackageId>Best.Conventional</PackageId>
     <Title>Best.Conventional</Title>
     <Authors>Andrew Best</Authors>

--- a/src/Core/Conventional/Conventional.csproj
+++ b/src/Core/Conventional/Conventional.csproj
@@ -42,7 +42,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.4.1" />
     <PackageReference Include="Mono.Cecil" Version="0.10.0" />
-    <PackageReference Include="System.Data.Common" Version="4.3.0" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
   </ItemGroup>
 </Project>

--- a/src/Core/Conventional/Conventional.csproj
+++ b/src/Core/Conventional/Conventional.csproj
@@ -43,6 +43,6 @@
     <PackageReference Include="Microsoft.CSharp" Version="4.4.1" />
     <PackageReference Include="Mono.Cecil" Version="0.10.0" />
     <PackageReference Include="System.Data.Common" Version="4.3.0" />
-    <PackageReference Include="System.Data.SqlClient" Version="4.8.5" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
   </ItemGroup>
 </Project>

--- a/src/Core/Conventional/Conventional.csproj
+++ b/src/Core/Conventional/Conventional.csproj
@@ -13,6 +13,7 @@
     <Copyright>Copyright © 2017, Andrew Best</Copyright>
     <Version>0.0.0.0</Version>
     <PackageVersion>0.0.0.0</PackageVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <None Remove="Conventions\Database\AllCheckConstraintsMustBeNamedConventionSpecification.sql" />

--- a/src/Core/global.json
+++ b/src/Core/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "3.1.000",
-    "rollForward": "minor"
+    "version": "8.0.401",
+    "rollForward": "latestFeature"
   }
 }

--- a/src/Core/global.json
+++ b/src/Core/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.401",
-    "rollForward": "latestFeature"
+    "version": "8.0.303",
+    "rollForward": "feature"
   }
 }


### PR DESCRIPTION
This commit https://github.com/andrewabest/Conventional/commit/a72a98809f9c818a5b425cb497093b836831b9f6 bumped Conventional from `netstandard2.0` to `netstandard2.1`.

Unfortunately, this makes it impossible for .NET Framework projects to use `Best.Conventional` versions `10.x` and `11.x`.

Older versions of `Best.Conventional` depend on older versions of `System.Data.SqlClient` which have CVEs.

My understanding is that there is no way currently to release hotfixes to older versions of `Best.Conventional`.

By targeting back to `netstandard2.0` older .NET Framework projects can still use the latest version of `Best.Conventional` (with the latest and greatest features) with any current or future CVEs also able to be addressed easily and correctly (here).

I have tested this using:
1. The existing `Best.Conventional` tests (all tests still pass).
2. A preexisting .NET Framework project (all tests still pass).
3. A preexisting .NET Core project (all tests still pass).

Please advise if there is anything else I can do to assist in getting this PR ready to land. :)

I will provide a separate PR to fix the same issue in `Best.Conventional.Roslyn` once this has landed, as `Best.Conventional.Roslyn` depends on the `Best.Conventional` NuGet package.